### PR TITLE
fix(symphony): rename bot username iv-agent → ivagent (GitHub doesn't allow hyphens)

### DIFF
--- a/.github/workflows/symphony-auto-assign-bot.yml
+++ b/.github/workflows/symphony-auto-assign-bot.yml
@@ -1,11 +1,11 @@
-name: Symphony — auto-assign iv-agent when daemon claims issue
+name: Symphony — auto-assign ivagent when daemon claims issue
 
 # When the daemon flips an issue to symphony/in-progress, self-assign
-# the iv-agent bot account so the issue's Assignee field reflects who
+# the ivagent bot account so the issue's Assignee field reflects who
 # is working it. This enables "click Assign yourself" takeover semantics.
 #
-# Bot username: iv-agent
-# NOTE: if the iv-agent GitHub account is renamed, update the single
+# Bot username: ivagent
+# NOTE: if the ivagent GitHub account is renamed, update the single
 # constant below. The account may not exist yet (see operations#23).
 # If it doesn't exist, gh's --add-assignee will fail gracefully; the
 # workflow is ready and will activate once the account is created.
@@ -19,17 +19,17 @@ permissions:
 
 jobs:
   auto-assign-bot:
-    name: Assign iv-agent on daemon claim
+    name: Assign ivagent on daemon claim
     runs-on: ubuntu-latest
     # Guard: only fire when the label that was just added is symphony/in-progress
     if: github.event.label.name == 'symphony/in-progress'
     steps:
-      - name: Assign iv-agent if no assignee yet
+      - name: Assign ivagent if no assignee yet
         uses: actions/github-script@v7
         with:
           script: |
             // Bot username constant — update here if account is renamed
-            const BOT_USER = 'iv-agent';
+            const BOT_USER = 'ivagent';
 
             const issue = context.payload.issue;
 

--- a/.github/workflows/symphony-human-assignee-handoff.yml
+++ b/.github/workflows/symphony-human-assignee-handoff.yml
@@ -10,9 +10,9 @@ name: Symphony — hand off to human when Chairman assigns themselves
 # Loop safety: Workflow A (auto-assign-bot) fires on `labeled`, not
 # `assigned`. Workflow B (this file) fires on `assigned`. Workflow A's
 # bot self-assign triggers this workflow, but guard #1 below catches
-# iv-agent and exits — no loop.
+# ivagent and exits — no loop.
 #
-# Bot username: iv-agent
+# Bot username: ivagent
 # NOTE: update the BOT_USER constant if the account is renamed.
 
 on:
@@ -32,7 +32,7 @@ jobs:
         with:
           script: |
             // Bot username constant — update here if account is renamed
-            const BOT_USER = 'iv-agent';
+            const BOT_USER = 'ivagent';
 
             const assignee = context.payload.assignee?.login;
             const issue = context.payload.issue;
@@ -71,7 +71,7 @@ jobs:
               }
             }
 
-            // Remove iv-agent as assignee if present (clean handoff — only
+            // Remove ivagent as assignee if present (clean handoff — only
             // the human is assigned going forward)
             const botIsAssigned = (issue.assignees || [])
               .some(a => a.login === BOT_USER);


### PR DESCRIPTION
Mechanical rename: all occurrences of `iv-agent` → `ivagent` in both Symphony bot workflow files.