### PR TITLE
feat(openapi): Phase 5 — CI drift detection + events schema

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ concurrency:
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
       - 'api/**'
       - 'src/**'
@@ -15,7 +15,7 @@ on:
       - 'vercel.json'
       - '.github/workflows/ci-cd.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
       - 'api/**'
       - 'src/**'
@@ -27,72 +27,75 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [18.x, 20.x]
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Run linting
-      run: npm run lint || echo "Linting not configured yet"
-      
-    - name: Run tests
-      run: npm test
 
-    - name: Generate test coverage
-      run: npm run test:coverage
-      
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage/lcov.info
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linting
+        run: npm run lint || echo "Linting not configured yet"
+
+      - name: Check OpenAPI spec drift
+        run: npm run docs:check
+
+      - name: Run tests
+        run: npm test
+
+      - name: Generate test coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
 
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Run security audit
-      run: npm audit --audit-level moderate
-      
-    - name: Check for known vulnerabilities
-      run: npm audit --audit-level high
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run security audit
+        run: npm audit --audit-level moderate
+
+      - name: Check for known vulnerabilities
+        run: npm audit --audit-level high
 
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: [test, security-scan]
     if: github.ref == 'refs/heads/develop'
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Deploy to Vercel Staging
-      uses: amondnet/vercel-action@v25
-      with:
-        vercel-token: ${{ secrets.VERCEL_TOKEN }}
-        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-        vercel-args: '--prod=false'
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel Staging
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod=false'
 
   deploy-production:
     name: Deploy to Production
@@ -106,82 +109,82 @@ jobs:
       !startsWith(github.event.head_commit.message, 'chore:')
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Deploy to Vercel Production
-      id: deploy
-      uses: amondnet/vercel-action@v25
-      with:
-        vercel-token: ${{ secrets.VERCEL_TOKEN }}
-        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-        vercel-args: '--prod'
+      - name: Deploy to Vercel Production
+        id: deploy
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'
 
-    - name: Wait for deployment to be ready
-      run: sleep 30
+      - name: Wait for deployment to be ready
+        run: sleep 30
 
-    - name: Health check
-      run: |
-        echo "Running health check..."
-        RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" ${{ steps.deploy.outputs.preview-url }}/api/health)
-        if [ $RESPONSE -eq 200 ]; then
-          echo "✅ Health check passed"
-        else
-          echo "❌ Health check failed with status $RESPONSE"
-          exit 1
-        fi
+      - name: Health check
+        run: |
+          echo "Running health check..."
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" ${{ steps.deploy.outputs.preview-url }}/api/health)
+          if [ $RESPONSE -eq 200 ]; then
+            echo "✅ Health check passed"
+          else
+            echo "❌ Health check failed with status $RESPONSE"
+            exit 1
+          fi
 
-    - name: Verify database connectivity
-      run: |
-        echo "Checking database connection..."
-        DB_STATUS=$(curl -s ${{ steps.deploy.outputs.preview-url }}/api/health | jq -r '.checks.database')
-        if [ "$DB_STATUS" = "healthy" ]; then
-          echo "✅ Database connectivity verified"
-        else
-          echo "❌ Database connectivity check failed"
-          exit 1
-        fi
+      - name: Verify database connectivity
+        run: |
+          echo "Checking database connection..."
+          DB_STATUS=$(curl -s ${{ steps.deploy.outputs.preview-url }}/api/health | jq -r '.checks.database')
+          if [ "$DB_STATUS" = "healthy" ]; then
+            echo "✅ Database connectivity verified"
+          else
+            echo "❌ Database connectivity check failed"
+            exit 1
+          fi
 
-    - name: Verify environment variables
-      run: |
-        echo "Checking environment configuration..."
-        ENV_STATUS=$(curl -s ${{ steps.deploy.outputs.preview-url }}/api/health | jq -r '.checks.environment')
-        if [ "$ENV_STATUS" = "healthy" ]; then
-          echo "✅ Environment variables verified"
-        else
-          echo "❌ Environment variables check failed"
-          exit 1
-        fi
+      - name: Verify environment variables
+        run: |
+          echo "Checking environment configuration..."
+          ENV_STATUS=$(curl -s ${{ steps.deploy.outputs.preview-url }}/api/health | jq -r '.checks.environment')
+          if [ "$ENV_STATUS" = "healthy" ]; then
+            echo "✅ Environment variables verified"
+          else
+            echo "❌ Environment variables check failed"
+            exit 1
+          fi
 
-    - name: Check for critical alerts
-      run: |
-        echo "Checking for critical alerts..."
-        CRITICAL_ALERTS=$(curl -s ${{ steps.deploy.outputs.preview-url }}/api/alerts?action=status | jq -r '.alerts.critical')
-        if [ "$CRITICAL_ALERTS" -eq 0 ]; then
-          echo "✅ No critical alerts"
-        else
-          echo "⚠️  Warning: $CRITICAL_ALERTS critical alerts detected"
-        fi
+      - name: Check for critical alerts
+        run: |
+          echo "Checking for critical alerts..."
+          CRITICAL_ALERTS=$(curl -s ${{ steps.deploy.outputs.preview-url }}/api/alerts?action=status | jq -r '.alerts.critical')
+          if [ "$CRITICAL_ALERTS" -eq 0 ]; then
+            echo "✅ No critical alerts"
+          else
+            echo "⚠️  Warning: $CRITICAL_ALERTS critical alerts detected"
+          fi
 
   notify:
     name: Notify Deployment
     runs-on: ubuntu-latest
     needs: [deploy-staging, deploy-production]
     if: always()
-    
+
     steps:
-    - name: Notify Success
-      if: needs.deploy-staging.result == 'success' || needs.deploy-production.result == 'success'
-      run: |
-        echo "✅ Deployment successful!"
-        echo "Staging: ${{ needs.deploy-staging.result }}"
-        echo "Production: ${{ needs.deploy-production.result }}"
-        
-    - name: Notify Failure
-      if: needs.deploy-staging.result == 'failure' || needs.deploy-production.result == 'failure'
-      run: |
-        echo "❌ Deployment failed!"
-        echo "Staging: ${{ needs.deploy-staging.result }}"
-        echo "Production: ${{ needs.deploy-production.result }}"
-        exit 1
+      - name: Notify Success
+        if: needs.deploy-staging.result == 'success' || needs.deploy-production.result == 'success'
+        run: |
+          echo "✅ Deployment successful!"
+          echo "Staging: ${{ needs.deploy-staging.result }}"
+          echo "Production: ${{ needs.deploy-production.result }}"
+
+      - name: Notify Failure
+        if: needs.deploy-staging.result == 'failure' || needs.deploy-production.result == 'failure'
+        run: |
+          echo "❌ Deployment failed!"
+          echo "Staging: ${{ needs.deploy-staging.result }}"
+          echo "Production: ${{ needs.deploy-production.result }}"
+          exit 1

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clean": "rm -rf dist build",
     "build:watch": "tsc --project api/tsconfig.json --watch",
     "type-check": "tsc --project api/tsconfig.json --noEmit",
+    "docs:check": "ts-node --project tsconfig.json scripts/check-openapi-drift.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/scripts/check-openapi-drift.ts
+++ b/scripts/check-openapi-drift.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env ts-node
+/**
+ * OpenAPI drift detector.
+ *
+ * Checks that spec paths ↔ Express route registrations stay in sync.
+ * Exit 0 = clean. Exit 1 = drift detected (blocks CI).
+ *
+ * Rules:
+ *   - Every path in the spec must have a corresponding Express route (stale spec check).
+ *   - Every public Express route must be in the spec OR in EXCLUDED_EXPRESS_ROUTES (undocumented check).
+ *
+ * When adding a new route:
+ *   → Register it in src/openapi/schemas/<tag>.ts first (schema-first pattern).
+ *   → If the route is intentionally internal/admin/deprecated, add it to EXCLUDED_EXPRESS_ROUTES below.
+ */
+
+import { openApiDocument } from '../src/openapi/spec';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ── Exclusion list ────────────────────────────────────────────────────────────
+// Express routes that are intentionally absent from the public spec.
+// Format: "METHOD /openapi/style/path" (Express :param → {param}).
+
+const EXCLUDED_EXPRESS_ROUTES = new Set([
+  // Infrastructure / health / test
+  'GET /health',
+  'GET /api/v1/health',
+  'GET /api/v1/test',
+  // Dev / debug — never ship to 3rd parties
+  'GET /dev-profiles',
+  'GET /api/v1/debug/cors',
+  'GET /api/v1/dev/permissions',
+  // Redirect alias — documented as GET /api/v1/user/me
+  'GET /api/v1/users/me',
+  // Admin — internal operations only
+  'GET /api/v1/admin/apps/pending',
+  'POST /api/v1/admin/apps/{appId}/review',
+  // Marketplace: seller-side item mutations (not yet public developer API)
+  'POST /api/v1/marketplace/items',
+  'PUT /api/v1/marketplace/items/{id}',
+  'DELETE /api/v1/marketplace/items/{id}',
+  // Marketplace: admin-only category mutations
+  'POST /api/v1/marketplace/categories',
+  'PUT /api/v1/marketplace/categories/{id}',
+  'DELETE /api/v1/marketplace/categories/{id}',
+  // Shadowed duplicate: a second GET /api/v1/marketplace/categories registration
+  // (no-auth, collections-table version at line ~3395) is shadowed by the
+  // validateApiKey registration — Express uses first match. Already in spec.
+  // Spec infrastructure — not part of the API contract
+  'GET /api/openapi.json',
+]);
+
+// Route path prefixes that are entirely excluded (deprecated tenant API).
+const EXCLUDED_PREFIXES = ['/api/v1/tenant/'];
+
+// ── Extract Express routes from api/index.ts ──────────────────────────────────
+
+const indexPath = path.resolve(__dirname, '../api/index.ts');
+const source = fs.readFileSync(indexPath, 'utf-8');
+
+// Matches: app.get('/path') or app.post( '/path') or app.delete("/path")
+const routePattern = /app\.(get|post|put|patch|delete)\s*\(\s*['"`](\/[^'"`\n]+)['"`]/gi;
+
+const expressRoutes = new Set<string>();
+let m: RegExpExecArray | null;
+
+while ((m = routePattern.exec(source)) !== null) {
+  const method = m[1].toUpperCase();
+  // Convert Express :param → OpenAPI {param}
+  const openApiPath = m[2].replace(/:([^/\s]+)/g, '{$1}');
+  expressRoutes.add(`${method} ${openApiPath}`);
+}
+
+// ── Extract spec paths ────────────────────────────────────────────────────────
+
+const specEntries = new Set<string>();
+const methods = ['get', 'post', 'put', 'patch', 'delete'];
+
+for (const [specPath, pathItem] of Object.entries(openApiDocument.paths ?? {})) {
+  for (const method of methods) {
+    if (method in (pathItem as object)) {
+      specEntries.add(`${method.toUpperCase()} ${specPath}`);
+    }
+  }
+}
+
+// ── Compare ───────────────────────────────────────────────────────────────────
+
+const stalePaths: string[] = [];
+const undocumented: string[] = [];
+
+// 1. Spec paths not found in Express (stale spec entry)
+for (const entry of specEntries) {
+  if (!expressRoutes.has(entry)) {
+    stalePaths.push(entry);
+  }
+}
+
+// 2. Express routes not in spec and not excluded (undocumented public route)
+for (const entry of expressRoutes) {
+  const routePath = entry.split(' ')[1];
+  if (EXCLUDED_PREFIXES.some((prefix) => routePath.startsWith(prefix))) continue;
+  if (EXCLUDED_EXPRESS_ROUTES.has(entry)) continue;
+  if (!specEntries.has(entry)) {
+    undocumented.push(entry);
+  }
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+let drift = false;
+
+if (stalePaths.length > 0) {
+  console.error('\n❌ STALE SPEC ENTRIES — in spec but not in Express:');
+  stalePaths.forEach((p) => console.error(`   ${p}`));
+  console.error('   → Remove from src/openapi/schemas/ or add the missing Express route.\n');
+  drift = true;
+}
+
+if (undocumented.length > 0) {
+  console.error('\n❌ UNDOCUMENTED ROUTES — in Express but not in spec:');
+  undocumented.forEach((p) => console.error(`   ${p}`));
+  console.error(
+    '\n   → Register in src/openapi/schemas/<tag>.ts (see api/patterns/openapi-schema-first.md)' +
+      '\n   → OR add to EXCLUDED_EXPRESS_ROUTES in scripts/check-openapi-drift.ts if intentionally internal.\n'
+  );
+  drift = true;
+}
+
+if (!drift) {
+  console.log(
+    `✅ OpenAPI spec in sync — ${specEntries.size} spec paths, ` +
+      `${expressRoutes.size} Express routes (${EXCLUDED_EXPRESS_ROUTES.size} excluded).`
+  );
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/src/openapi/schemas/events.ts
+++ b/src/openapi/schemas/events.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import { registry } from '../registry';
+
+// ── Schemas ───────────────────────────────────────────────────────────────────
+
+export const EventSchema = registry.register(
+  'Event',
+  z.object({
+    id: z.string().uuid(),
+    title: z.string(),
+    description: z.string(),
+    startDate: z.string().datetime(),
+    endDate: z.string().datetime(),
+    location: z.string().nullable(),
+    isOnline: z.boolean(),
+    category: z.string(),
+    organizer: z.string().uuid(),
+    maxAttendees: z.number().int().nullable(),
+    currentAttendees: z.number().int().nullable(),
+    price: z.number().min(0),
+    tags: z.array(z.string()),
+    imageUrl: z.string().url().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+);
+
+const EventIdParamSchema = z.object({ eventId: z.string().uuid() });
+
+// POST body — required fields validated inline by handler
+export const CreateEventBodySchema = z
+  .object({
+    title: z.string().min(1),
+    description: z.string().min(1),
+    startDate: z.string().datetime(),
+    endDate: z.string().datetime(),
+    isOnline: z.boolean(),
+    category: z.string().min(1),
+    location: z.string().nullable().optional(),
+    maxAttendees: z.number().int().positive().nullable().optional(),
+    price: z.number().min(0).optional(),
+    tags: z.array(z.string()).max(20).optional(),
+    imageUrl: z.string().url().nullable().optional(),
+  })
+  .passthrough();
+
+// ── Path registrations ───────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/oriva/events',
+  tags: ['Events'],
+  summary: 'List events',
+  description: 'Returns active events with optional filtering by category and date range.',
+  request: {
+    query: z.object({
+      category: z.string().optional(),
+      startDate: z.string().datetime().optional(),
+      endDate: z.string().datetime().optional(),
+      limit: z.number().int().max(100).default(20).optional(),
+      offset: z.number().int().min(0).default(0).optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Events list',
+      content: {
+        'application/json': {
+          schema: z.object({
+            ok: z.boolean(),
+            success: z.boolean(),
+            data: z.array(EventSchema),
+            total: z.number().int(),
+            limit: z.number().int(),
+            offset: z.number().int(),
+          }),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/oriva/events/{eventId}',
+  tags: ['Events'],
+  summary: 'Get event',
+  request: { params: EventIdParamSchema },
+  responses: {
+    200: {
+      description: 'Event details',
+      content: {
+        'application/json': {
+          schema: z.object({
+            ok: z.boolean(),
+            success: z.boolean(),
+            data: EventSchema,
+          }),
+        },
+      },
+    },
+    404: { description: 'Event not found' },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/oriva/events',
+  tags: ['Events'],
+  summary: 'Create event',
+  security: [{ BearerAuth: [] }],
+  request: {
+    body: { content: { 'application/json': { schema: CreateEventBodySchema } } },
+  },
+  responses: {
+    201: {
+      description: 'Event created',
+      content: {
+        'application/json': {
+          schema: z.object({
+            ok: z.boolean(),
+            success: z.boolean(),
+            data: EventSchema,
+            message: z.string(),
+          }),
+        },
+      },
+    },
+    400: { description: 'Validation error — missing required fields or invalid category' },
+    401: { description: 'Unauthorized' },
+  },
+});

--- a/src/openapi/schemas/marketplace.ts
+++ b/src/openapi/schemas/marketplace.ts
@@ -425,7 +425,8 @@ registry.registerPath({
   path: '/api/v1/marketplace/categories/tree',
   tags: ['Marketplace'],
   summary: 'Category tree',
-  description: 'Returns marketplace categories as a hierarchical tree from the collections table.',
+  description:
+    'Returns marketplace categories as a hierarchical tree from the collections table. Children are nested category objects of the same shape.',
   responses: {
     200: {
       description: 'Category tree',
@@ -436,7 +437,7 @@ registry.registerPath({
             success: z.boolean(),
             data: z.array(
               CategorySchema.extend({
-                children: z.array(z.lazy(() => CategorySchema)).optional(),
+                children: z.array(z.record(z.unknown())).optional(),
               })
             ),
           }),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -10,6 +10,7 @@ import './schemas/sessions';
 import './schemas/marketplace';
 import './schemas/developer';
 import './schemas/entries';
+import './schemas/events';
 
 const generator = new OpenApiGeneratorV31(registry.definitions);
 


### PR DESCRIPTION
## User Story

**As a** platform developer
**I want to** have CI block any PR that adds an Express route without a matching OpenAPI spec entry
**So I can** maintain spec-first discipline automatically without relying on code review attention

## Summary

- `scripts/check-openapi-drift.ts` — bidirectional drift checker: spec paths not in Express = stale spec; Express routes not in spec and not excluded = undocumented public route
- `src/openapi/schemas/events.ts` — Events tag (3 paths: `GET /api/oriva/events`, `GET /api/oriva/events/{eventId}`, `POST /api/oriva/events`) discovered by the drift checker
- `src/openapi/spec.ts` — side-effect import for events schema
- `src/openapi/schemas/marketplace.ts` — fixed `z.lazy()` → `z.record(z.unknown())` (zod-to-openapi v7 does not support `ZodLazy`)
- `package.json` — `"docs:check"` script wired
- `.github/workflows/ci-cd.yml` — "Check OpenAPI spec drift" step added to `test` job

Final state: `✅ OpenAPI spec in sync — 46 spec paths, 62 Express routes (16 excluded).`

## User Criteria

- [ ] `npm run docs:check` exits 0 on a clean repo
- [ ] Adding an Express route without spec registration causes `npm run docs:check` to exit 1
- [ ] CI `test` job runs the drift check on every PR to `main`/`develop`

## Tech Criteria

- [ ] TypeScript compiles with no errors
- [ ] Existing tests pass
- [ ] No new console errors or warnings

## Skills to consult

- openapi-schema-first

## Enhance existing approach

- [x] Prefer extending existing code/patterns over creating new abstractions

---

**Agent**: Use relevant sub-agents and skills for implementation. Read related src/ pattern files BEFORE writing code.