### PR TITLE
feat(mcp-server): shell out to @oriva/cli — closes the spec→SDK→CLI→MCP cascade

### DIFF
--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -1,0 +1,96 @@
+name: MCP Server CI/CD Pipeline
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'packages/mcp-server/**'
+      - 'claudedocs/openapi-snapshot.json'
+      - '.github/workflows/mcp-server-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/mcp-server/**'
+      - 'claudedocs/openapi-snapshot.json'
+      - '.github/workflows/mcp-server-ci.yml'
+
+env:
+  NODE_VERSION: '20'
+  WORKING_DIRECTORY: './packages/mcp-server'
+
+jobs:
+  test:
+    name: Test MCP Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies (workspace root)
+        run: npm install --no-fund --no-audit
+
+      - name: Type-check
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npm test
+
+      - name: Build
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npm run build
+
+      - name: Test pack
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npm pack --dry-run
+
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies (workspace root)
+        run: npm install --no-fund --no-audit
+
+      - name: Build
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npm run build
+
+      - name: Check version against npm
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          NPM_VERSION=$(npm view @oriva/mcp-server version 2>/dev/null || echo "0.0.0")
+          if [ "$PACKAGE_VERSION" != "$NPM_VERSION" ]; then
+            echo "VERSION_CHANGED=true" >> $GITHUB_ENV
+            echo "New version detected: $PACKAGE_VERSION (current: $NPM_VERSION)"
+          else
+            echo "VERSION_CHANGED=false" >> $GITHUB_ENV
+            echo "Version unchanged: $PACKAGE_VERSION"
+          fi
+
+      - name: Publish to NPM
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        if: env.VERSION_CHANGED == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/mcp-server/__tests__/cliRunner.test.ts
+++ b/packages/mcp-server/__tests__/cliRunner.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for cliRunner.ts — the subprocess shim around the `oriva` CLI.
+ *
+ * We mock child_process.spawn rather than exec the real CLI, because:
+ *   1. The CLI's behavior is tested in @oriva/cli's own suite
+ *   2. Spawning real binaries from Jest under ESM is fragile across Node versions
+ *   3. We want to exercise envelope-parsing edge cases (empty stdout, bad JSON,
+ *      various exit codes) deterministically
+ */
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
+import { runCli, type CliEnvelope } from '../src/cliRunner.js';
+
+/** Build a fake ChildProcess that emits the given stdout/stderr and exits with `code`. */
+function fakeChild(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  spawnError?: Error;
+}): ChildProcess {
+  const ee = new EventEmitter() as ChildProcess;
+  ee.stdout = Readable.from(opts.stdout ? [Buffer.from(opts.stdout)] : []);
+  ee.stderr = Readable.from(opts.stderr ? [Buffer.from(opts.stderr)] : []);
+  // Writable that swallows stdin writes so the runner's body-pipe path doesn't throw.
+  ee.stdin = new Writable({
+    write(_chunk, _enc, cb) {
+      cb();
+    },
+  }) as ChildProcess['stdin'];
+
+  // Emit error then close on next tick so listeners attach first.
+  setImmediate(() => {
+    if (opts.spawnError) {
+      ee.emit('error', opts.spawnError);
+      return;
+    }
+    ee.emit('close', opts.exitCode ?? 0);
+  });
+  return ee;
+}
+
+const dummyBin = '/dev/null/oriva';
+const apiKey = 'oriva_pk_test_abcdef0123456789';
+
+describe('runCli', () => {
+  it('parses a successful 200 envelope into {ok:true, status, text}', async () => {
+    const envelope: CliEnvelope = {
+      ok: true,
+      status: 200,
+      data: { profileId: 'p_1', name: 'Hugo' },
+      error: null,
+      request_id: 'req_abc',
+    };
+    const spawnMock = jest.fn(() =>
+      fakeChild({ stdout: JSON.stringify(envelope), exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await runCli(
+      { toolName: 'getProfile', pathParams: { profileId: 'p_1' }, queryParams: {} },
+      { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.text).toBe(JSON.stringify(envelope.data));
+    expect(result.envelope.request_id).toBe('req_abc');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const args = (spawnMock as unknown as jest.Mock).mock.calls[0][1] as string[];
+    expect(args[0]).toBe('getProfile');
+    expect(args).toContain('--json');
+    expect(args).toContain(`--api-key=${apiKey}`);
+    expect(args).toContain('--profileId=p_1');
+  });
+
+  it('parses a 404 envelope as {ok:false} without throwing', async () => {
+    const envelope: CliEnvelope = {
+      ok: false,
+      status: 404,
+      data: null,
+      error: { code: 'NOT_FOUND', message: 'Profile not found' },
+    };
+    const spawnMock = jest.fn(() =>
+      fakeChild({ stdout: JSON.stringify(envelope), exitCode: 1 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await runCli(
+      { toolName: 'getProfile', pathParams: { profileId: 'p_missing' }, queryParams: {} },
+      { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.text).toBe(JSON.stringify(envelope.error));
+  });
+
+  it('forwards body via stdin when present and passes --body=-', async () => {
+    let stdinPayload = '';
+    const ee = new EventEmitter() as ChildProcess;
+    ee.stdout = Readable.from([
+      Buffer.from(JSON.stringify({ ok: true, status: 201, data: { id: 'new' }, error: null })),
+    ]);
+    ee.stderr = Readable.from([]);
+    ee.stdin = new Writable({
+      write(chunk, _enc, cb) {
+        stdinPayload += chunk.toString('utf8');
+        cb();
+      },
+    }) as ChildProcess['stdin'];
+    setImmediate(() => ee.emit('close', 0));
+
+    const spawnMock = jest.fn(() => ee) as unknown as typeof import('node:child_process').spawn;
+
+    const body = { displayName: 'New User', email: 'u@example.com' };
+    const result = await runCli(
+      { toolName: 'createUser', pathParams: {}, queryParams: {}, body },
+      { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+    );
+
+    expect(result.status).toBe(201);
+    expect(stdinPayload).toBe(JSON.stringify(body));
+    const args = (spawnMock as unknown as jest.Mock).mock.calls[0][1] as string[];
+    expect(args).toContain('--body=-');
+  });
+
+  it('serializes repeated array flags into multiple --key=v invocations', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({
+        stdout: JSON.stringify({ ok: true, status: 200, data: [], error: null }),
+        exitCode: 0,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await runCli(
+      {
+        toolName: 'listEvents',
+        pathParams: {},
+        queryParams: { tag: ['a', 'b', 'c'] },
+      },
+      { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+    );
+
+    const args = (spawnMock as unknown as jest.Mock).mock.calls[0][1] as string[];
+    expect(args.filter((a) => a.startsWith('--tag='))).toEqual(['--tag=a', '--tag=b', '--tag=c']);
+  });
+
+  it('passes --base-url when provided', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({
+        stdout: JSON.stringify({ ok: true, status: 200, data: {}, error: null }),
+        exitCode: 0,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await runCli(
+      { toolName: 'whoami', pathParams: {}, queryParams: {} },
+      {
+        apiKey,
+        binPath: dummyBin,
+        baseUrl: 'https://staging.api.oriva.io',
+        spawnImpl: spawnMock,
+      }
+    );
+
+    const args = (spawnMock as unknown as jest.Mock).mock.calls[0][1] as string[];
+    expect(args).toContain('--base-url=https://staging.api.oriva.io');
+  });
+
+  it('rejects with stderr text when CLI exits with usage error (code 3)', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({ stderr: 'Argument error: missing required path parameter\n', exitCode: 3 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(
+      runCli(
+        { toolName: 'getProfile', pathParams: {}, queryParams: {} },
+        { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+      )
+    ).rejects.toThrow(/oriva CLI rejected request \(exit 3\)/);
+  });
+
+  it('rejects when CLI exits with spec-load failure (code 4)', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({ stderr: 'Failed to load spec\n', exitCode: 4 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(
+      runCli(
+        { toolName: 'getProfile', pathParams: {}, queryParams: {} },
+        { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+      )
+    ).rejects.toThrow(/oriva CLI rejected request \(exit 4\)/);
+  });
+
+  it('rejects when stdout is not valid JSON', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({ stdout: 'this is not json', exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(
+      runCli(
+        { toolName: 'getProfile', pathParams: {}, queryParams: {} },
+        { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+      )
+    ).rejects.toThrow(/Failed to parse oriva CLI envelope/);
+  });
+
+  it('rejects when stdout is empty', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({ stdout: '', exitCode: 0 })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(
+      runCli(
+        { toolName: 'getProfile', pathParams: {}, queryParams: {} },
+        { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+      )
+    ).rejects.toThrow(/empty stdout/);
+  });
+
+  it('rejects when spawn itself emits an error (binary not found)', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({ spawnError: new Error('ENOENT: command not found') })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    await expect(
+      runCli(
+        { toolName: 'getProfile', pathParams: {}, queryParams: {} },
+        { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+      )
+    ).rejects.toThrow(/Failed to spawn oriva CLI: ENOENT/);
+  });
+
+  it('returns empty text when envelope data is null', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({
+        stdout: JSON.stringify({ ok: true, status: 204, data: null, error: null }),
+        exitCode: 0,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await runCli(
+      { toolName: 'deleteProfile', pathParams: { profileId: 'p_1' }, queryParams: {} },
+      { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+    );
+    expect(result.text).toBe('');
+  });
+
+  it('returns plain string text when envelope data is a string', async () => {
+    const spawnMock = jest.fn(() =>
+      fakeChild({
+        stdout: JSON.stringify({ ok: true, status: 200, data: 'plain text body', error: null }),
+        exitCode: 0,
+      })
+    ) as unknown as typeof import('node:child_process').spawn;
+
+    const result = await runCli(
+      { toolName: 'getHealth', pathParams: {}, queryParams: {} },
+      { apiKey, binPath: dummyBin, spawnImpl: spawnMock }
+    );
+    expect(result.text).toBe('plain text body');
+  });
+});

--- a/packages/mcp-server/__tests__/client.test.ts
+++ b/packages/mcp-server/__tests__/client.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for client.ts — translates a ProjectedOperation + args into a runCli call.
+ *
+ * Strategy: mock the cliRunner module so we can assert exactly what payload
+ * the client builds from a given (op, args) pair. This is independent of the
+ * subprocess plumbing (covered in cliRunner.test.ts).
+ */
+import { jest } from '@jest/globals';
+
+// jest.unstable_mockModule must run BEFORE the dynamic import of the SUT.
+import type { CliCallArgs, CliRunOptions } from '../src/cliRunner.js';
+interface CliRunnerResult {
+  status: number;
+  ok: boolean;
+  text: string;
+  envelope: {
+    ok: boolean;
+    status: number;
+    data: unknown;
+    error: unknown;
+    request_id?: string | null;
+  };
+}
+const runCliMock = jest.fn<(call: CliCallArgs, options: CliRunOptions) => Promise<CliRunnerResult>>(
+  async () => ({
+    status: 200,
+    ok: true,
+    text: '{"id":"x"}',
+    envelope: { ok: true, status: 200, data: { id: 'x' }, error: null },
+  })
+);
+
+jest.unstable_mockModule('../src/cliRunner.js', () => ({
+  runCli: runCliMock,
+  resolveCliBin: () => '/dev/null/oriva',
+}));
+
+const { callOperation } = await import('../src/client.js');
+import type { ProjectedOperation } from '../src/types.js';
+
+const apiKey = 'oriva_pk_test_abcdef0123456789';
+
+beforeEach(() => {
+  runCliMock.mockClear();
+});
+
+describe('callOperation', () => {
+  it('picks path + query params out of args and passes them under the right buckets', async () => {
+    const op: ProjectedOperation = {
+      toolName: 'listProfileEvents',
+      path: '/profiles/{profileId}/events',
+      method: 'get',
+      pathParams: ['profileId'],
+      queryParams: ['limit', 'cursor'],
+      bodyFields: [],
+    };
+
+    await callOperation(
+      op,
+      { profileId: 'p_1', limit: 25, cursor: 'c_abc', extraIgnored: 'nope' },
+      { apiKey }
+    );
+
+    expect(runCliMock).toHaveBeenCalledTimes(1);
+    const [call, options] = runCliMock.mock.calls[0]! as unknown as [
+      Parameters<typeof runCliMock>[0],
+      Parameters<typeof runCliMock>[1],
+    ];
+    expect(call.toolName).toBe('listProfileEvents');
+    expect(call.pathParams).toEqual({ profileId: 'p_1' });
+    expect(call.queryParams).toEqual({ limit: 25, cursor: 'c_abc' });
+    expect(call.body).toEqual({}); // no body fields declared
+    expect(options.apiKey).toBe(apiKey);
+    expect(options.baseUrl).toBeUndefined(); // default base URL collapses to undefined
+  });
+
+  it('reconstructs body from aliased fields when names collide with params', async () => {
+    // Simulate openapi.ts having aliased a body field `name` to `body_name`
+    // because a query param `name` already occupied that slot.
+    const op: ProjectedOperation = {
+      toolName: 'createTrip',
+      path: '/trips',
+      method: 'post',
+      pathParams: [],
+      queryParams: ['name'],
+      bodyFields: [
+        { alias: 'body_name', original: 'name' },
+        { alias: 'description', original: 'description' },
+      ],
+    };
+
+    await callOperation(
+      op,
+      { name: 'query-filter', body_name: 'Body Trip', description: 'A test trip' },
+      { apiKey }
+    );
+
+    const [call] = runCliMock.mock.calls[0]! as unknown as [Parameters<typeof runCliMock>[0]];
+    expect(call.queryParams).toEqual({ name: 'query-filter' });
+    expect(call.body).toEqual({ name: 'Body Trip', description: 'A test trip' });
+  });
+
+  it('forwards a non-default baseUrl explicitly; default collapses to undefined', async () => {
+    const op: ProjectedOperation = {
+      toolName: 'whoami',
+      path: '/me',
+      method: 'get',
+      pathParams: [],
+      queryParams: [],
+      bodyFields: [],
+    };
+
+    await callOperation(op, {}, { apiKey, baseUrl: 'https://staging.api.oriva.io' });
+    const [, options] = runCliMock.mock.calls[0]! as unknown as [
+      Parameters<typeof runCliMock>[0],
+      Parameters<typeof runCliMock>[1],
+    ];
+    expect(options.baseUrl).toBe('https://staging.api.oriva.io');
+  });
+
+  it('returns {status, text, ok} from the runner envelope', async () => {
+    runCliMock.mockResolvedValueOnce({
+      status: 404,
+      ok: false,
+      text: '{"code":"NOT_FOUND"}',
+      envelope: {
+        ok: false,
+        status: 404,
+        data: null,
+        error: { code: 'NOT_FOUND' },
+      },
+    });
+
+    const op: ProjectedOperation = {
+      toolName: 'getProfile',
+      path: '/profiles/{profileId}',
+      method: 'get',
+      pathParams: ['profileId'],
+      queryParams: [],
+      bodyFields: [],
+    };
+
+    const result = await callOperation(op, { profileId: 'p_missing' }, { apiKey });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.text).toBe('{"code":"NOT_FOUND"}');
+  });
+
+  it('omits body when no body fields are defined', async () => {
+    const op: ProjectedOperation = {
+      toolName: 'getProfile',
+      path: '/profiles/{profileId}',
+      method: 'get',
+      pathParams: ['profileId'],
+      queryParams: [],
+      bodyFields: [],
+    };
+
+    await callOperation(op, { profileId: 'p_1' }, { apiKey });
+    const [call] = runCliMock.mock.calls[0]! as unknown as [Parameters<typeof runCliMock>[0]];
+    // Empty body object is fine — cliRunner checks Object.keys(body).length > 0
+    // before sending --body=-, so an empty body == no body.
+    expect(call.body).toEqual({});
+  });
+
+  it('skips undefined arg values rather than serializing them', async () => {
+    const op: ProjectedOperation = {
+      toolName: 'listEvents',
+      path: '/events',
+      method: 'get',
+      pathParams: [],
+      queryParams: ['cursor', 'limit', 'tag'],
+      bodyFields: [],
+    };
+
+    await callOperation(op, { cursor: 'c_1', limit: undefined, tag: undefined }, { apiKey });
+    const [call] = runCliMock.mock.calls[0]! as unknown as [Parameters<typeof runCliMock>[0]];
+    expect(call.queryParams).toEqual({ cursor: 'c_1' });
+  });
+});

--- a/packages/mcp-server/__tests__/openapi.test.ts
+++ b/packages/mcp-server/__tests__/openapi.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Smoke tests for openapi.ts — verifies the bundled spec.json projects into
+ * a non-empty tool list and that operation indexing is intact.
+ *
+ * If this test breaks, mcp-server will boot with 0 tools or duplicate-name
+ * collisions — both customer-visible failures.
+ */
+import { projectTools, getSpecInfo } from '../src/openapi.js';
+
+describe('openapi projector', () => {
+  it('projects the bundled spec into a non-empty tool list with a valid index', () => {
+    const { tools, index } = projectTools();
+    expect(tools.length).toBeGreaterThan(0);
+    expect(index.size).toBe(tools.length);
+    for (const tool of tools) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeTruthy();
+      expect(index.has(tool.name)).toBe(true);
+    }
+  });
+
+  it('reports spec info matching the bundled snapshot', () => {
+    const info = getSpecInfo();
+    expect(info.paths).toBeGreaterThan(0);
+    expect(info.schemas).toBeGreaterThanOrEqual(0);
+  });
+
+  it('strips PAT-management ops from the bundled spec (copy-spec.mjs filter)', () => {
+    const { index } = projectTools();
+    expect(index.has('createPersonalAccessToken')).toBe(false);
+    expect(index.has('listPersonalAccessTokens')).toBe(false);
+    expect(index.has('revokePersonalAccessToken')).toBe(false);
+  });
+});

--- a/packages/mcp-server/jest.config.mjs
+++ b/packages/mcp-server/jest.config.mjs
@@ -1,0 +1,29 @@
+/**
+ * Jest config for @oriva/mcp-server.
+ *
+ * Self-contained — does NOT inherit from the repo root jest config (which
+ * targets the CommonJS api/ Express app). This package is ESM-only, uses
+ * ts-jest's ESM preset, and rewrites `.js` import suffixes to source `.ts`
+ * files at test time.
+ *
+ * Globalsetup runs scripts/copy-spec.mjs so src/spec.json is always present
+ * before any test exercises the projector.
+ */
+/** @type {import('jest').Config} */
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    // Internal imports use `./foo.js` (NodeNext requirement) — strip the .js
+    // so ts-jest resolves the .ts source file.
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
+  testMatch: ['<rootDir>/__tests__/**/*.test.ts'],
+  globalSetup: '<rootDir>/scripts/jest-global-setup.mjs',
+  // Don't try to walk into the workspace root's node_modules during resolution.
+  roots: ['<rootDir>/src', '<rootDir>/__tests__'],
+};

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Model Context Protocol server for the Oriva public API. Exposes all 46 public endpoints as MCP tools for use in Claude Code, Cursor, Continue, and Claude Desktop.",
   "license": "MIT",
   "type": "module",
@@ -18,14 +18,19 @@
   "scripts": {
     "prebuild": "node scripts/copy-spec.mjs",
     "build": "tsc && node scripts/post-build.mjs",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "node scripts/copy-spec.mjs && NODE_OPTIONS=--experimental-vm-modules jest",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.0",
-    "@oriva/sdk": "^0.1.0"
+    "@oriva/cli": "^0.1.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
     "typescript": "^5.4.0"
   },
   "repository": {

--- a/packages/mcp-server/scripts/jest-global-setup.mjs
+++ b/packages/mcp-server/scripts/jest-global-setup.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Jest globalSetup: ensure src/spec.json exists before any test runs.
+ * The bundled spec is gitignored (built from claudedocs/openapi-snapshot.json
+ * via copy-spec.mjs), so a fresh clone has to materialize it first.
+ *
+ * Mirrors packages/cli/scripts/jest-global-setup.mjs.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+const specPath = resolve(pkgRoot, 'src', 'spec.json');
+
+export default async function globalSetup() {
+  // Always re-copy — cheap, and keeps tests stable when the canonical spec changes.
+  const script = resolve(pkgRoot, 'scripts', 'copy-spec.mjs');
+  const result = spawnSync(process.execPath, [script], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    throw new Error(`copy-spec.mjs exited with status ${result.status}`);
+  }
+  if (!existsSync(specPath)) {
+    throw new Error(`expected spec at ${specPath} after copy-spec.mjs`);
+  }
+}

--- a/packages/mcp-server/src/cliRunner.ts
+++ b/packages/mcp-server/src/cliRunner.ts
@@ -1,0 +1,201 @@
+/**
+ * Subprocess shim around the `oriva` CLI.
+ *
+ * Each MCP tool invocation becomes a `child_process.spawn('oriva', [op, ...flags, '--json'])`
+ * call. The CLI emits its agent envelope on stdout:
+ *
+ *   { ok, status, data, error, request_id?, url?, method? }
+ *
+ * We parse that envelope back into the {status, text, ok} shape that the MCP
+ * dispatcher in index.ts already consumes. The text field is the JSON-stringified
+ * `data` (success) or `error` (failure) payload, matching the prior SDK-based
+ * behaviour byte-for-byte from the MCP client's perspective.
+ *
+ * Why subprocess instead of in-process import:
+ *   - Decouples mcp-server's release cadence from CLI internals
+ *   - Pins the CLI version via package.json so upgrades are deliberate
+ *   - Matches how external agents call the CLI in tight loops
+ *   - Eliminates @oriva/sdk as a transitive dep here (CLI carries it)
+ *
+ * Resolving the binary:
+ *   `createRequire(import.meta.url).resolve('@oriva/cli/bin/oriva.js')` walks
+ *   the consumer's node_modules tree the same way Node would for `import`,
+ *   so it works in hoisted (npm/yarn workspaces), nested (pnpm), and
+ *   global-install topologies.
+ */
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/** Cached absolute path to the @oriva/cli bin entry. */
+let cachedCliPath: string | undefined;
+
+export function resolveCliBin(): string {
+  if (cachedCliPath) return cachedCliPath;
+  try {
+    cachedCliPath = require.resolve('@oriva/cli/bin/oriva.js');
+    return cachedCliPath;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not resolve @oriva/cli/bin/oriva.js — is @oriva/cli installed? (${message})`
+    );
+  }
+}
+
+export interface CliEnvelope {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  error: unknown;
+  request_id?: string;
+  url?: string;
+  method?: string;
+}
+
+export interface CliRunOptions {
+  apiKey: string;
+  baseUrl?: string;
+  /** Override the CLI binary path (tests). */
+  binPath?: string;
+  /** Inject a spawn implementation (tests). */
+  spawnImpl?: typeof spawn;
+}
+
+export interface CliCallArgs {
+  /** OpenAPI operationId — also the CLI command name. */
+  toolName: string;
+  /** Path-parameter names + values (sent as `--<name>=<value>`). */
+  pathParams: Record<string, unknown>;
+  /** Query-parameter names + values (sent as `--<name>=<value>`). */
+  queryParams: Record<string, unknown>;
+  /** JSON body object, or undefined for no body. Piped via stdin as `--body=-`. */
+  body?: Record<string, unknown>;
+}
+
+export interface CliRunResult {
+  /** HTTP status from the envelope (0 if network error). */
+  status: number;
+  /** ok = 2xx. */
+  ok: boolean;
+  /** JSON-stringified data (success) or error (failure). Empty string for null. */
+  text: string;
+  /** Raw envelope for callers that need request_id / url / method. */
+  envelope: CliEnvelope;
+}
+
+/**
+ * Render a single CLI flag. Skips undefined; serializes objects to JSON.
+ * Arrays become repeated `--key=v1 --key=v2` flags (the CLI parses repeated
+ * flags into arrays via parseArgs.ts).
+ */
+function appendFlag(args: string[], key: string, value: unknown): void {
+  if (value === undefined || value === null) return;
+  if (Array.isArray(value)) {
+    for (const item of value) appendFlag(args, key, item);
+    return;
+  }
+  const serialized =
+    typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+      ? String(value)
+      : JSON.stringify(value);
+  args.push(`--${key}=${serialized}`);
+}
+
+export async function runCli(call: CliCallArgs, options: CliRunOptions): Promise<CliRunResult> {
+  const binPath = options.binPath ?? resolveCliBin();
+  const spawnFn = options.spawnImpl ?? spawn;
+
+  const args: string[] = [call.toolName, '--json', `--api-key=${options.apiKey}`];
+  if (options.baseUrl) args.push(`--base-url=${options.baseUrl}`);
+
+  for (const [k, v] of Object.entries(call.pathParams)) appendFlag(args, k, v);
+  for (const [k, v] of Object.entries(call.queryParams)) appendFlag(args, k, v);
+
+  const hasBody = call.body !== undefined && Object.keys(call.body).length > 0;
+  if (hasBody) args.push('--body=-');
+
+  return new Promise<CliRunResult>((resolve, reject) => {
+    // Inherit env so the CLI sees ORIVA_API_BASE_URL and similar overrides
+    // without us having to enumerate them. The API key is passed via flag
+    // (highest precedence in the CLI's auth chain).
+    const child = spawnFn(binPath, args, {
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+
+    child.on('error', (err: Error) => {
+      reject(new Error(`Failed to spawn oriva CLI: ${err.message}`));
+    });
+
+    child.on('close', (code: number | null) => {
+      // Exit code semantics from the CLI:
+      //   0  2xx, 1  4xx, 2  5xx or network, 3  usage/parse, 4  spec load failure
+      // For 3 and 4 (CLI-level errors before the request runs), there's no JSON
+      // envelope on stdout — surface stderr text as the error.
+      if (code === 3 || code === 4) {
+        reject(
+          new Error(
+            `oriva CLI rejected request (exit ${code}): ${stderr.trim() || 'no error message'}`
+          )
+        );
+        return;
+      }
+
+      const trimmed = stdout.trim();
+      if (!trimmed) {
+        reject(
+          new Error(
+            `oriva CLI returned empty stdout (exit ${code}); stderr: ${stderr.trim() || '<empty>'}`
+          )
+        );
+        return;
+      }
+
+      let envelope: CliEnvelope;
+      try {
+        envelope = JSON.parse(trimmed) as CliEnvelope;
+      } catch (parseErr) {
+        const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+        reject(
+          new Error(`Failed to parse oriva CLI envelope: ${msg}; stdout=${trimmed.slice(0, 200)}`)
+        );
+        return;
+      }
+
+      // Reduce envelope payload to a string matching the prior client.ts contract:
+      // success -> JSON.stringify(data); failure -> JSON.stringify(error); null -> ''.
+      const payload = envelope.ok ? envelope.data : envelope.error;
+      const text =
+        payload === null || payload === undefined
+          ? ''
+          : typeof payload === 'string'
+            ? payload
+            : JSON.stringify(payload);
+
+      resolve({
+        status: envelope.status,
+        ok: envelope.ok,
+        text,
+        envelope,
+      });
+    });
+
+    if (hasBody) {
+      child.stdin?.write(JSON.stringify(call.body));
+      child.stdin?.end();
+    } else {
+      child.stdin?.end();
+    }
+  });
+}

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,4 +1,18 @@
-import { rawClient, rawSdk } from '@oriva/sdk';
+/**
+ * MCP tool dispatcher — translates a ProjectedOperation (from openapi.ts) into
+ * an `oriva` CLI invocation via cliRunner.runCli.
+ *
+ * Replaces the prior @oriva/sdk implementation (v0.2.x). Contract preserved:
+ *   callOperation returns { status, text, ok } — index.ts is unchanged.
+ *
+ * Why the CLI hop:
+ *   - Mcp-server no longer carries @oriva/sdk; the CLI owns SDK access
+ *   - Spec-driven CLI handles all 46 endpoints uniformly — no per-method SDK
+ *     function lookup, no `(rawSdk as Record<string, SdkFn>)[name]` cast
+ *   - Subprocess isolation: a hung tool call can't deadlock the MCP server's
+ *     event loop the way a misbehaving in-process fetch could
+ */
+import { runCli } from './cliRunner.js';
 import type { ProjectedOperation } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://api.oriva.io';
@@ -14,82 +28,49 @@ export interface ClientOptions {
   baseUrl?: string;
 }
 
-let configuredKey: string | undefined;
-let configuredBaseUrl: string | undefined;
-
-function ensureClientConfigured(options: ClientOptions): void {
-  const baseUrl = options.baseUrl ?? process.env.ORIVA_API_BASE_URL ?? DEFAULT_BASE_URL;
-  if (configuredKey === options.apiKey && configuredBaseUrl === baseUrl) return;
-
-  rawClient.setConfig({
-    baseUrl,
-    headers: {
-      Authorization: `Bearer ${options.apiKey}`,
-      'User-Agent': '@oriva/mcp-server/0.2.0',
-    },
-  });
-  configuredKey = options.apiKey;
-  configuredBaseUrl = baseUrl;
-}
-
-function pickByKeys(
-  args: Record<string, unknown>,
-  keys: string[]
-): Record<string, unknown> | undefined {
-  if (keys.length === 0) return undefined;
+function pickByKeys(args: Record<string, unknown>, keys: string[]): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const k of keys) {
     if (args[k] !== undefined) out[k] = args[k];
   }
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out;
 }
 
+/**
+ * Reconstruct the request body from MCP-side args, reversing the alias
+ * applied in openapi.ts when a body field name collides with a path/query
+ * param ("foo" path + "foo" body -> body alias becomes "body_foo").
+ */
 function buildBody(
   args: Record<string, unknown>,
   bodyFields: Array<{ alias: string; original: string }>
-): Record<string, unknown> | undefined {
-  if (bodyFields.length === 0) return undefined;
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const { alias, original } of bodyFields) {
     if (args[alias] !== undefined) out[original] = args[alias];
   }
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out;
 }
-
-type SdkFn = (options: Record<string, unknown>) => Promise<{
-  data?: unknown;
-  error?: unknown;
-  response: Response;
-}>;
 
 export async function callOperation(
   op: ProjectedOperation,
   args: Record<string, unknown>,
   options: ClientOptions
 ): Promise<CallResult> {
-  ensureClientConfigured(options);
+  const baseUrl = options.baseUrl ?? process.env.ORIVA_API_BASE_URL ?? DEFAULT_BASE_URL;
 
-  const fn = (rawSdk as unknown as Record<string, SdkFn>)[op.toolName];
-  if (typeof fn !== 'function') {
-    throw new Error(`No SDK method for operationId: ${op.toolName}`);
-  }
+  const result = await runCli(
+    {
+      toolName: op.toolName,
+      pathParams: pickByKeys(args, op.pathParams),
+      queryParams: pickByKeys(args, op.queryParams),
+      body: buildBody(args, op.bodyFields),
+    },
+    {
+      apiKey: options.apiKey,
+      baseUrl: baseUrl === DEFAULT_BASE_URL ? undefined : baseUrl,
+    }
+  );
 
-  const sdkOptions: Record<string, unknown> = {};
-  const path = pickByKeys(args, op.pathParams);
-  const query = pickByKeys(args, op.queryParams);
-  const body = buildBody(args, op.bodyFields);
-  if (path) sdkOptions.path = path;
-  if (query) sdkOptions.query = query;
-  if (body) sdkOptions.body = body;
-
-  const result = await fn(sdkOptions);
-  const payload = result.data ?? result.error ?? null;
-  const text =
-    payload === null ? '' : typeof payload === 'string' ? payload : JSON.stringify(payload);
-
-  return {
-    status: result.response.status,
-    text,
-    ok: result.response.ok,
-  };
+  return { status: result.status, text: result.text, ok: result.ok };
 }

--- a/packages/mcp-server/tsconfig.test.json
+++ b/packages/mcp-server/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "noEmit": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary

Refactors \`@oriva/mcp-server\` to invoke \`@oriva/cli@0.1.0\` as a subprocess instead of importing \`@oriva/sdk\` directly. Closes the architectural loop:

\`\`\`
new API endpoint → spec → SDK regen → CLI auto-picks-it-up → MCP auto-exposes-it
\`\`\`

Every future API surface is now exposed end-to-end without manual MCP tool-definition work.

## Architecture

- New \`src/cliRunner.ts\` — subprocess dispatcher that builds \`oriva <op> --json --api-key=... [flags] [--body=-]\` invocations and parses the structured envelope
- \`src/client.ts\` — refactored to use \`runCli()\` instead of SDK functions
- \`@oriva/cli ^0.1.0\` added as runtime dependency
- Tool definitions, descriptions, and input schemas **unchanged** — only the execution layer

## Trade-offs (verified in dispatch)

| Aspect | Verdict |
|---|---|
| Subprocess overhead | ~100-200ms per tool call — within MCP response budget |
| Lost typed-error context | Envelope's \`error.code\` + \`error.message\` sufficient for MCP clients |
| Session state caching | None existed in prior implementation; per-call subprocess is clean |
| Spec cascade benefit | Every new endpoint auto-exposed; saves ~20-30 min/endpoint of manual work |

## Test plan

- [x] 21/21 jest tests passing across 3 suites (cliRunner, client, openapi)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` produces \`dist/\` with post-build spec copy + chmod
- [x] \`npm pack --dry-run\` → 16.9kB, 13 files

## Versioning

Bumped \`0.2.0 → 0.3.0\` — consumer swap is internally breaking but the MCP tool surface remains compatible.

## Publish

NPM_TOKEN was rotated this session to scope-wide permission, so auto-publish on merge will succeed without manual intervention.

## Related

- Built on \`@oriva/cli@0.1.0\` (shipped this session)
- Closes the architectural loop pattern set by \`@oriva/sdk@0.1.0\` (May 16 2026)