### PR TITLE
feat(spec): sync PersonalAccessToken ops — validates the auto-cascade end-to-end

### DIFF
--- a/.github/workflows/api-sdk-ci.yml
+++ b/.github/workflows/api-sdk-ci.yml
@@ -40,6 +40,14 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: npm run generate
 
+      # The openapi-ts generator's bundled Prettier doesn't read the workspace's
+      # .prettierrc. Husky's pre-commit lint-staged DOES — so committed SDK
+      # output is workspace-Prettier-formatted. CI must apply workspace Prettier
+      # too or the drift-guard fails on every PR.
+      - name: Apply workspace Prettier to generated SDK
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npx prettier --write 'src/generated/**/*.ts'
+
       - name: Drift guard — fail if generated SDK differs from committed
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -36,11 +36,17 @@ jobs:
       - name: Install dependencies (workspace root)
         run: npm install --no-fund --no-audit
 
-      # Note: drift-guard deferred to v0.1.1 — canonical claudedocs/openapi-snapshot.json
-      # is Prettier-formatted (compact arrays), but JSON.stringify can't match that
-      # byte-for-byte. The bundled packages/cli/openapi-snapshot.json is maintained
-      # manually for now; v0.1.1 will adopt Prettier in copy-spec.mjs and re-enable
-      # the guard.
+      # Drift-guard: copy-spec.mjs does a verbatim byte copy of the canonical
+      # claudedocs/openapi-snapshot.json, so the bundled CLI snapshot must
+      # always match. If they drift, someone regenerated the canonical without
+      # re-running copy-spec.mjs (or vice-versa). Re-enabled in v0.1.1 after
+      # copy-spec.mjs adopted verbatim-copy strategy.
+      - name: Refresh bundled snapshot
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: node scripts/copy-spec.mjs
+
+      - name: Drift-guard (CLI snapshot must match canonical)
+        run: git diff --exit-code packages/cli/openapi-snapshot.json
 
       - name: Type-check
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -78,8 +84,9 @@ jobs:
         run: npm install --no-fund --no-audit
 
       # Publish uses the committed packages/cli/openapi-snapshot.json verbatim —
-      # whatever was tested in the test job is what ships. See test-job comment
-      # re: drift-guard deferral to v0.1.1.
+      # whatever was tested in the test job is what ships. copy-spec.mjs (fired
+      # by prebuild) is a verbatim byte copy of the canonical, so it's a no-op
+      # if the committed bundled snapshot matches.
 
       - name: Build
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/claudedocs/openapi-snapshot.json
+++ b/claudedocs/openapi-snapshot.json
@@ -896,6 +896,115 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "CreatedPersonalToken": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "success": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "token": {
+                "type": "string",
+                "description": "Full token value — displayed ONCE. Store it now; it cannot be retrieved again."
+              },
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "name": {
+                "type": "string"
+              },
+              "prefix": {
+                "type": "string",
+                "description": "First 20 characters of the token, safe to display later."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "expires_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "token",
+              "id",
+              "name",
+              "prefix",
+              "created_at",
+              "expires_at"
+            ]
+          }
+        },
+        "required": ["ok", "success", "data"]
+      },
+      "PersonalTokenSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "expires_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "is_active": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "prefix",
+          "created_at",
+          "last_used_at",
+          "expires_at",
+          "is_active"
+        ]
+      },
+      "PersonalTokenList": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "success": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PersonalTokenSummary"
+            }
+          }
+        },
+        "required": ["ok", "success", "data"]
       }
     },
     "parameters": {}
@@ -3659,6 +3768,122 @@
           },
           "404": {
             "description": "Event not found"
+          }
+        }
+      }
+    },
+    "/api/v1/me/tokens": {
+      "post": {
+        "operationId": "createPersonalAccessToken",
+        "tags": ["PersonalTokens"],
+        "summary": "Create a Personal Access Token",
+        "description": "Issues a new Personal Access Token (PAT) scoped to the authenticated account. The full token value is returned **once** and cannot be retrieved again. PATs carry broad `[\"read\",\"write\"]` permissions and are intended for personal tooling (e.g. MCP servers).",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100,
+                    "description": "Human-readable label for the token"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "ISO 8601 expiry date. Omit for a non-expiring token."
+                  }
+                },
+                "required": ["name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Token created — contains the full one-time token value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedPersonalToken"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
+        }
+      },
+      "get": {
+        "operationId": "listPersonalAccessTokens",
+        "tags": ["PersonalTokens"],
+        "summary": "List Personal Access Tokens",
+        "description": "Returns all PATs belonging to the authenticated account. Full token values and hashes are never returned.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of PATs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonalTokenList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
+        }
+      }
+    },
+    "/api/v1/me/tokens/{id}": {
+      "delete": {
+        "operationId": "revokePersonalAccessToken",
+        "tags": ["PersonalTokens"],
+        "summary": "Revoke a Personal Access Token",
+        "description": "Sets `is_active = false` on the token (soft-delete). The row is preserved for audit purposes. Returns 404 if the token does not belong to this account.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Revoked successfully"
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "404": {
+            "description": "Token not found or does not belong to this account"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16946,7 +16946,7 @@
     },
     "packages/cli": {
       "name": "@oriva/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "oriva": "bin/oriva.js"
@@ -16962,7 +16962,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@oriva/sdk": "0.1.x"
+        "@oriva/sdk": "0.1.x || 0.2.x"
       },
       "peerDependenciesMeta": {
         "@oriva/sdk": {
@@ -18216,7 +18216,7 @@
     },
     "packages/mcp-server": {
       "name": "@oriva/mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",
@@ -20755,7 +20755,7 @@
     },
     "packages/sdk": {
       "name": "@oriva/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.97.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3567,6 +3567,10 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@oriva/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@oriva/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
@@ -16940,23 +16944,1651 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "packages/cli": {
+      "name": "@oriva/cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "oriva": "bin/oriva.js"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.12",
+        "@types/node": "^20.0.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.4",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@oriva/sdk": "0.1.x"
+      },
+      "peerDependenciesMeta": {
+        "@oriva/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/@jest/core/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "packages/cli/node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/cli/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "packages/cli/node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "packages/cli/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/cli/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/cli/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cli/node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/jest-cli/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "packages/cli/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cli/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cli/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/cli/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/cli/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "packages/mcp-server": {
       "name": "@oriva/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",
-        "@oriva/sdk": "*"
+        "@oriva/cli": "^0.1.0"
       },
       "bin": {
         "oriva-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.12",
         "@types/node": "^20.0.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.4",
         "typescript": "^5.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/core/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/mcp-server/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "packages/mcp-server/node_modules/@types/node": {
@@ -16969,12 +18601,884 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages/mcp-server/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mcp-server/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/mcp-server/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "packages/mcp-server/node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mcp-server/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mcp-server/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/mcp-server/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/mcp-server/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mcp-server/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/mcp-server/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/mcp-server/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/mcp-server/node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/jest-cli/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/mcp-server/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/mcp-server/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/mcp-server/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/mcp-server/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mcp-server/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "packages/mcp-server/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/mcp-server/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "packages/plugin-sdk": {
       "name": "@oriva/plugin-sdk",

--- a/packages/cli/openapi-snapshot.json
+++ b/packages/cli/openapi-snapshot.json
@@ -6,8 +6,14 @@
     "description": "Public API for 3rd party Oriva developers. Authenticate with your API key as a Bearer token."
   },
   "servers": [
-    { "url": "https://api.oriva.io", "description": "Production" },
-    { "url": "http://localhost:3002", "description": "Local BFF proxy" }
+    {
+      "url": "https://api.oriva.io",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:3002",
+      "description": "Local BFF proxy"
+    }
   ],
   "components": {
     "securitySchemes": {
@@ -23,209 +29,76 @@
       }
     },
     "schemas": {
-      "AuthSessionResponse": {
-        "type": "object",
-        "properties": {
-          "user": {
-            "type": "object",
-            "properties": {
-              "id": { "type": "string" },
-              "email": { "type": ["string", "null"], "format": "email" },
-              "display_name": { "type": ["string", "null"] },
-              "username": { "type": ["string", "null"] },
-              "subscription_tier": { "type": "string" },
-              "created_at": { "type": "string", "format": "date-time" }
-            },
-            "required": [
-              "id",
-              "email",
-              "display_name",
-              "username",
-              "subscription_tier",
-              "created_at"
-            ]
-          },
-          "access_token": { "type": "string" },
-          "refresh_token": { "type": "string" },
-          "expires_in": { "type": "integer" }
-        },
-        "required": ["user", "access_token", "refresh_token", "expires_in"]
-      },
-      "AuthProfileResponse": {
-        "type": "object",
-        "properties": {
-          "ok": { "type": "boolean" },
-          "success": { "type": "boolean" },
-          "data": {
-            "type": "object",
-            "properties": {
-              "id": { "type": "string", "format": "uuid" },
-              "email": { "type": ["string", "null"], "format": "email" },
-              "displayName": { "type": "string" },
-              "avatar": { "type": ["string", "null"], "format": "uri" },
-              "authType": { "type": "string" },
-              "permissions": { "type": "array", "items": { "type": "string" } },
-              "lastLogin": { "type": "string", "format": "date-time" },
-              "accountStatus": { "type": "string" },
-              "twoFactorEnabled": { "type": "boolean" },
-              "emailVerified": { "type": "boolean" }
-            },
-            "required": [
-              "id",
-              "email",
-              "displayName",
-              "avatar",
-              "authType",
-              "permissions",
-              "lastLogin",
-              "accountStatus",
-              "twoFactorEnabled",
-              "emailVerified"
-            ]
-          }
-        },
-        "required": ["ok", "success", "data"]
-      },
-      "RawProfileResponse": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string" },
-          "display_name": { "type": ["string", "null"] },
-          "username": { "type": ["string", "null"] },
-          "bio": { "type": ["string", "null"] },
-          "avatar_url": { "type": ["string", "null"], "format": "uri" },
-          "location": { "type": ["string", "null"] },
-          "website_url": { "type": ["string", "null"], "format": "uri" }
-        },
-        "required": [
-          "id",
-          "display_name",
-          "username",
-          "bio",
-          "avatar_url",
-          "location",
-          "website_url"
-        ]
-      },
-      "TokenRefreshResponse": {
-        "type": "object",
-        "properties": {
-          "access_token": { "type": "string" },
-          "refresh_token": { "type": "string" },
-          "expires_in": { "type": "integer" }
-        },
-        "required": ["access_token", "refresh_token", "expires_in"]
-      },
-      "ProfileSummary": {
-        "type": "object",
-        "properties": {
-          "profileId": { "type": "string", "example": "ext_a1b2c3d4e5f6a7b8" },
-          "profileName": { "type": "string" },
-          "isActive": { "type": "boolean" },
-          "avatar": { "type": ["string", "null"], "format": "uri" },
-          "isDefault": { "type": "boolean" }
-        },
-        "required": [
-          "profileId",
-          "profileName",
-          "isActive",
-          "avatar",
-          "isDefault"
-        ]
-      },
-      "UpdatedProfile": {
-        "type": "object",
-        "properties": {
-          "ok": { "type": "boolean" },
-          "success": { "type": "boolean" },
-          "data": {
-            "type": "object",
-            "properties": {
-              "profileId": { "type": "string" },
-              "profileName": { "type": "string" },
-              "isActive": { "type": "boolean" },
-              "avatar": { "type": ["string", "null"], "format": "uri" },
-              "bio": { "type": ["string", "null"] },
-              "location": { "type": ["string", "null"] },
-              "updatedAt": { "type": "string", "format": "date-time" }
-            },
-            "required": [
-              "profileId",
-              "profileName",
-              "isActive",
-              "avatar",
-              "bio",
-              "location",
-              "updatedAt"
-            ]
-          },
-          "message": { "type": "string" }
-        },
-        "required": ["ok", "success", "data"]
-      },
-      "GroupSummary": {
-        "type": "object",
-        "properties": {
-          "groupId": { "type": "string", "format": "uuid" },
-          "groupName": { "type": "string" },
-          "memberCount": { "type": "integer" },
-          "isActive": { "type": "boolean" },
-          "role": { "type": "string", "example": "admin" },
-          "description": { "type": ["string", "null"] },
-          "image_url": { "type": ["string", "null"], "format": "uri" },
-          "external_link": { "type": ["string", "null"], "format": "uri" }
-        },
-        "required": [
-          "groupId",
-          "groupName",
-          "memberCount",
-          "isActive",
-          "role",
-          "description",
-          "image_url",
-          "external_link"
-        ]
-      },
-      "GroupMember": {
-        "type": "object",
-        "properties": {
-          "memberId": { "type": "string", "format": "uuid" },
-          "displayName": { "type": "string" },
-          "role": { "type": "string" },
-          "joinedAt": { "type": "string", "format": "date-time" },
-          "avatar": { "type": ["string", "null"], "format": "uri" }
-        },
-        "required": ["memberId", "displayName", "role", "joinedAt", "avatar"]
-      },
       "UserMe": {
         "type": "object",
         "properties": {
-          "ok": { "type": "boolean" },
-          "success": { "type": "boolean" },
+          "ok": {
+            "type": "boolean"
+          },
+          "success": {
+            "type": "boolean"
+          },
           "data": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "format": "uuid" },
-              "username": { "type": ["string", "null"] },
-              "displayName": { "type": "string" },
-              "email": { "type": ["string", "null"], "format": "email" },
-              "bio": { "type": ["string", "null"] },
-              "location": { "type": ["string", "null"] },
-              "website": { "type": ["string", "null"], "format": "uri" },
-              "avatar": { "type": ["string", "null"], "format": "uri" },
-              "createdAt": { "type": "string", "format": "date-time" },
-              "updatedAt": { "type": "string", "format": "date-time" },
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "username": {
+                "type": ["string", "null"]
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "email": {
+                "type": ["string", "null"],
+                "format": "email"
+              },
+              "bio": {
+                "type": ["string", "null"]
+              },
+              "location": {
+                "type": ["string", "null"]
+              },
+              "website": {
+                "type": ["string", "null"],
+                "format": "uri"
+              },
+              "avatar": {
+                "type": ["string", "null"],
+                "format": "uri"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
               "apiKeyInfo": {
                 "type": "object",
                 "properties": {
-                  "keyId": { "type": "string" },
-                  "name": { "type": "string" },
-                  "userId": { "type": "string", "format": "uuid" },
+                  "keyId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
                   "permissions": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": {
+                      "type": "string"
+                    }
                   },
-                  "usageCount": { "type": "integer" }
+                  "usageCount": {
+                    "type": "integer"
+                  }
                 },
                 "required": [
                   "keyId",
@@ -256,18 +129,30 @@
       "AnalyticsSummary": {
         "type": "object",
         "properties": {
-          "ok": { "type": "boolean" },
-          "success": { "type": "boolean" },
+          "ok": {
+            "type": "boolean"
+          },
+          "success": {
+            "type": "boolean"
+          },
           "data": {
             "type": "object",
             "properties": {
               "overview": {
                 "type": "object",
                 "properties": {
-                  "totalEntries": { "type": "integer" },
-                  "totalResponses": { "type": "integer" },
-                  "totalGroups": { "type": "integer" },
-                  "installedApps": { "type": "integer" }
+                  "totalEntries": {
+                    "type": "integer"
+                  },
+                  "totalResponses": {
+                    "type": "integer"
+                  },
+                  "totalGroups": {
+                    "type": "integer"
+                  },
+                  "installedApps": {
+                    "type": "integer"
+                  }
                 },
                 "required": [
                   "totalEntries",
@@ -279,10 +164,18 @@
               "metrics": {
                 "type": "object",
                 "properties": {
-                  "entriesGrowth": { "type": "string" },
-                  "responseGrowth": { "type": "string" },
-                  "groupActivity": { "type": "string" },
-                  "appUsage": { "type": "string" }
+                  "entriesGrowth": {
+                    "type": "string"
+                  },
+                  "responseGrowth": {
+                    "type": "string"
+                  },
+                  "groupActivity": {
+                    "type": "string"
+                  },
+                  "appUsage": {
+                    "type": "string"
+                  }
                 },
                 "required": [
                   "entriesGrowth",
@@ -291,36 +184,381 @@
                   "appUsage"
                 ]
               },
-              "recentActivity": { "type": "array", "items": {} },
+              "recentActivity": {
+                "type": "array",
+                "items": {}
+              },
               "timeRange": {
                 "type": "object",
                 "properties": {
-                  "start": { "type": "string", "format": "date-time" },
-                  "end": { "type": "string", "format": "date-time" }
+                  "start": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "end": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
                 },
                 "required": ["start", "end"]
               }
             },
             "required": ["overview", "metrics", "recentActivity", "timeRange"]
           },
-          "message": { "type": "string" }
+          "message": {
+            "type": "string"
+          }
         },
         "required": ["ok", "success", "data"]
+      },
+      "ProfileSummary": {
+        "type": "object",
+        "properties": {
+          "profileId": {
+            "type": "string",
+            "example": "ext_a1b2c3d4e5f6a7b8"
+          },
+          "profileName": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "avatar": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "profileId",
+          "profileName",
+          "isActive",
+          "avatar",
+          "isDefault"
+        ]
+      },
+      "UpdatedProfile": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "profileId": {
+                "type": "string"
+              },
+              "profileName": {
+                "type": "string"
+              },
+              "isActive": {
+                "type": "boolean"
+              },
+              "avatar": {
+                "type": ["string", "null"],
+                "format": "uri"
+              },
+              "bio": {
+                "type": ["string", "null"]
+              },
+              "location": {
+                "type": ["string", "null"]
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "profileId",
+              "profileName",
+              "isActive",
+              "avatar",
+              "bio",
+              "location",
+              "updatedAt"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["ok", "success", "data"]
+      },
+      "GroupSummary": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "groupName": {
+            "type": "string"
+          },
+          "memberCount": {
+            "type": "integer"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "role": {
+            "type": "string",
+            "example": "admin"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "image_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "external_link": {
+            "type": ["string", "null"],
+            "format": "uri"
+          }
+        },
+        "required": [
+          "groupId",
+          "groupName",
+          "memberCount",
+          "isActive",
+          "role",
+          "description",
+          "image_url",
+          "external_link"
+        ]
+      },
+      "GroupMember": {
+        "type": "object",
+        "properties": {
+          "memberId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "avatar": {
+            "type": ["string", "null"],
+            "format": "uri"
+          }
+        },
+        "required": ["memberId", "displayName", "role", "joinedAt", "avatar"]
+      },
+      "AuthSessionResponse": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "email": {
+                "type": ["string", "null"],
+                "format": "email"
+              },
+              "display_name": {
+                "type": ["string", "null"]
+              },
+              "username": {
+                "type": ["string", "null"]
+              },
+              "subscription_tier": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "id",
+              "email",
+              "display_name",
+              "username",
+              "subscription_tier",
+              "created_at"
+            ]
+          },
+          "access_token": {
+            "type": "string"
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer"
+          }
+        },
+        "required": ["user", "access_token", "refresh_token", "expires_in"]
+      },
+      "AuthProfileResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "email": {
+                "type": ["string", "null"],
+                "format": "email"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "avatar": {
+                "type": ["string", "null"],
+                "format": "uri"
+              },
+              "authType": {
+                "type": "string"
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "lastLogin": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "accountStatus": {
+                "type": "string"
+              },
+              "twoFactorEnabled": {
+                "type": "boolean"
+              },
+              "emailVerified": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "email",
+              "displayName",
+              "avatar",
+              "authType",
+              "permissions",
+              "lastLogin",
+              "accountStatus",
+              "twoFactorEnabled",
+              "emailVerified"
+            ]
+          }
+        },
+        "required": ["ok", "success", "data"]
+      },
+      "RawProfileResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": ["string", "null"]
+          },
+          "username": {
+            "type": ["string", "null"]
+          },
+          "bio": {
+            "type": ["string", "null"]
+          },
+          "avatar_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "location": {
+            "type": ["string", "null"]
+          },
+          "website_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          }
+        },
+        "required": [
+          "id",
+          "display_name",
+          "username",
+          "bio",
+          "avatar_url",
+          "location",
+          "website_url"
+        ]
+      },
+      "TokenRefreshResponse": {
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "string"
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer"
+          }
+        },
+        "required": ["access_token", "refresh_token", "expires_in"]
       },
       "TeamMember": {
         "type": "object",
         "properties": {
-          "profileId": { "type": "string", "format": "uuid" },
-          "displayName": { "type": ["string", "null"] },
-          "username": { "type": ["string", "null"] },
-          "avatarUrl": { "type": ["string", "null"], "format": "uri" },
-          "role": { "type": "string" },
-          "joinedAt": { "type": "string", "format": "date-time" },
+          "profileId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displayName": {
+            "type": ["string", "null"]
+          },
+          "username": {
+            "type": ["string", "null"]
+          },
+          "avatarUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "role": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
           "group": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "format": "uuid" },
-              "name": { "type": "string" }
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "required": ["id", "name"]
           }
@@ -338,38 +576,80 @@
       "MarketplaceApp": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "external_id": { "type": "string" },
-          "name": { "type": "string" },
-          "slug": { "type": "string" },
-          "tagline": { "type": ["string", "null"] },
-          "description": { "type": ["string", "null"] },
-          "category": { "type": "string" },
-          "icon_url": { "type": ["string", "null"], "format": "uri" },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "tagline": {
+            "type": ["string", "null"]
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "category": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
           "screenshots": {
             "type": ["array", "null"],
-            "items": { "type": "string", "format": "uri" }
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
           },
-          "version": { "type": "string" },
-          "pricing_model": { "type": "string" },
+          "version": {
+            "type": "string"
+          },
+          "pricing_model": {
+            "type": "string"
+          },
           "pricing_config": {
             "type": ["object", "null"],
             "additionalProperties": {}
           },
-          "install_count": { "type": "integer" },
-          "developer_id": { "type": "string", "format": "uuid" },
-          "developer_name": { "type": "string" },
+          "install_count": {
+            "type": "integer"
+          },
+          "developer_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "developer_name": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "enum": ["draft", "pending_review", "approved", "rejected"]
           },
-          "is_active": { "type": "boolean" },
+          "is_active": {
+            "type": "boolean"
+          },
           "supported_audience": {
             "type": ["array", "null"],
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" }
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
         "required": [
           "id",
@@ -390,14 +670,24 @@
       "InstalledApp": {
         "type": "object",
         "properties": {
-          "installationId": { "type": "string", "format": "uuid" },
-          "installedAt": { "type": "string", "format": "date-time" },
-          "isActive": { "type": "boolean" },
+          "installationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "installedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
           "settings": {
             "type": ["object", "null"],
             "additionalProperties": {}
           },
-          "app": { "$ref": "#/components/schemas/MarketplaceApp" }
+          "app": {
+            "$ref": "#/components/schemas/MarketplaceApp"
+          }
         },
         "required": [
           "installationId",
@@ -410,17 +700,35 @@
       "MarketplaceItem": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "title": { "type": "string" },
-          "content": { "type": ["string", "null"] },
-          "profile_id": { "type": "string", "format": "uuid" },
-          "entry_type": { "type": "string" },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": ["string", "null"]
+          },
+          "profile_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "entry_type": {
+            "type": "string"
+          },
           "marketplace_metadata": {
             "type": ["object", "null"],
             "additionalProperties": {}
           },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" }
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
         "required": [
           "id",
@@ -434,16 +742,31 @@
       "Category": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "name": { "type": "string" },
-          "description": { "type": ["string", "null"] },
-          "collection_type": { "type": "string" },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "collection_type": {
+            "type": "string"
+          },
           "organization_rules": {
             "type": ["object", "null"],
             "additionalProperties": {}
           },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" }
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
         "required": [
           "id",
@@ -456,13 +779,31 @@
       "Entry": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "title": { "type": "string" },
-          "content": { "type": "string" },
-          "profile_id": { "type": "string", "format": "uuid" },
-          "audience_type": { "type": "string" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "audience_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
         "required": [
           "id",
@@ -477,22 +818,65 @@
       "Event": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "startDate": { "type": "string", "format": "date-time" },
-          "endDate": { "type": "string", "format": "date-time" },
-          "location": { "type": ["string", "null"] },
-          "isOnline": { "type": "boolean" },
-          "category": { "type": "string" },
-          "organizer": { "type": "string", "format": "uuid" },
-          "maxAttendees": { "type": ["integer", "null"] },
-          "currentAttendees": { "type": ["integer", "null"] },
-          "price": { "type": "number", "minimum": 0 },
-          "tags": { "type": "array", "items": { "type": "string" } },
-          "imageUrl": { "type": ["string", "null"], "format": "uri" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": ["string", "null"]
+          },
+          "isOnline": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "organizer": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "maxAttendees": {
+            "type": ["integer", "null"]
+          },
+          "currentAttendees": {
+            "type": ["integer", "null"]
+          },
+          "price": {
+            "type": "number",
+            "minimum": 0
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "imageUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
         "required": [
           "id",
@@ -516,8 +900,14 @@
       "CreatedPersonalToken": {
         "type": "object",
         "properties": {
-          "ok": { "type": "boolean", "enum": [true] },
-          "success": { "type": "boolean", "enum": [true] },
+          "ok": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "success": {
+            "type": "boolean",
+            "enum": [true]
+          },
           "data": {
             "type": "object",
             "properties": {
@@ -525,13 +915,21 @@
                 "type": "string",
                 "description": "Full token value — displayed ONCE. Store it now; it cannot be retrieved again."
               },
-              "id": { "type": "string", "format": "uuid" },
-              "name": { "type": "string" },
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "name": {
+                "type": "string"
+              },
               "prefix": {
                 "type": "string",
                 "description": "First 20 characters of the token, safe to display later."
               },
-              "created_at": { "type": "string", "format": "date-time" },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
               "expires_at": {
                 "type": ["string", "null"],
                 "format": "date-time"
@@ -552,13 +950,31 @@
       "PersonalTokenSummary": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "name": { "type": "string" },
-          "prefix": { "type": "string" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "last_used_at": { "type": ["string", "null"], "format": "date-time" },
-          "expires_at": { "type": ["string", "null"], "format": "date-time" },
-          "is_active": { "type": "boolean" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "expires_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "is_active": {
+            "type": "boolean"
+          }
         },
         "required": [
           "id",
@@ -573,11 +989,19 @@
       "PersonalTokenList": {
         "type": "object",
         "properties": {
-          "ok": { "type": "boolean", "enum": [true] },
-          "success": { "type": "boolean", "enum": [true] },
+          "ok": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "success": {
+            "type": "boolean",
+            "enum": [true]
+          },
           "data": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/PersonalTokenSummary" }
+            "items": {
+              "$ref": "#/components/schemas/PersonalTokenSummary"
+            }
           }
         },
         "required": ["ok", "success", "data"]
@@ -586,235 +1010,59 @@
     "parameters": {}
   },
   "paths": {
-    "/api/v1/auth/register": {
-      "post": {
-        "operationId": "register",
-        "tags": ["Auth"],
-        "summary": "Register a new user",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "email": { "type": "string", "format": "email" },
-                  "password": {
-                    "type": "string",
-                    "minLength": 8,
-                    "pattern": "[A-Z]"
-                  },
-                  "name": { "type": "string" },
-                  "username": { "type": "string" },
-                  "preferences": {}
-                },
-                "required": ["email", "password"]
-              }
-            }
+    "/api/v1/user/me": {
+      "get": {
+        "operationId": "getCurrentUser",
+        "tags": ["User"],
+        "summary": "Get current user",
+        "description": "Returns the authenticated user's active profile and API key metadata.",
+        "security": [
+          {
+            "ApiKeyAuth": []
           }
-        },
-        "responses": {
-          "201": {
-            "description": "User registered and session created",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthSessionResponse" }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation error — weak password or invalid email"
-          },
-          "409": { "description": "Email already registered" }
-        }
-      }
-    },
-    "/api/v1/auth/login": {
-      "post": {
-        "operationId": "login",
-        "tags": ["Auth"],
-        "summary": "Log in",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "email": { "type": "string", "format": "email" },
-                  "password": { "type": "string", "minLength": 1 }
-                },
-                "required": ["email", "password"]
-              }
-            }
-          }
-        },
+        ],
         "responses": {
           "200": {
-            "description": "Login successful",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthSessionResponse" }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation error — missing email or password"
-          },
-          "401": { "description": "Invalid credentials" }
-        }
-      }
-    },
-    "/api/v1/auth/logout": {
-      "post": {
-        "operationId": "logout",
-        "tags": ["Auth"],
-        "summary": "Log out",
-        "description": "Invalidates the current session. Requires Authorization header.",
-        "security": [{ "BearerAuth": [] }],
-        "responses": {
-          "204": { "description": "Logged out" },
-          "401": { "description": "Missing authorization header" }
-        }
-      }
-    },
-    "/api/v1/auth/token/refresh": {
-      "post": {
-        "operationId": "refreshToken",
-        "tags": ["Auth"],
-        "summary": "Refresh access token",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "refresh_token": { "type": "string", "minLength": 1 }
-                },
-                "required": ["refresh_token"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "New tokens issued",
+            "description": "Current user",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TokenRefreshResponse"
+                  "$ref": "#/components/schemas/UserMe"
                 }
               }
             }
           },
-          "400": { "description": "Validation error — missing refresh_token" },
-          "401": { "description": "Invalid or expired refresh token" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
-    "/api/v1/auth/profile": {
+    "/api/v1/analytics/summary": {
       "get": {
-        "operationId": "getAuthProfile",
-        "tags": ["Auth"],
-        "summary": "Get auth profile",
-        "description": "Returns the authenticated user identity and API key metadata.",
-        "security": [{ "ApiKeyAuth": [] }, { "BearerAuth": [] }],
+        "operationId": "getAnalyticsSummary",
+        "tags": ["Analytics"],
+        "summary": "Get analytics summary",
+        "description": "Returns 7-day usage analytics for the authenticated API key.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Auth profile",
+            "description": "Analytics summary",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthProfileResponse" }
-              }
-            }
-          },
-          "401": { "description": "Unauthorized" }
-        }
-      },
-      "patch": {
-        "operationId": "patchAuthProfile",
-        "tags": ["Auth"],
-        "summary": "Update profile (partial)",
-        "security": [{ "BearerAuth": [] }],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": { "type": "string" },
-                  "bio": { "type": "string" },
-                  "avatar_url": { "type": "string", "format": "uri" },
-                  "location": { "type": "string" },
-                  "website_url": { "type": "string", "format": "uri" }
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsSummary"
                 }
               }
             }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
           }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile row",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/RawProfileResponse" }
-              }
-            }
-          },
-          "400": { "description": "No fields provided" },
-          "401": { "description": "Unauthorized" }
-        }
-      },
-      "put": {
-        "operationId": "putAuthProfile",
-        "tags": ["Auth"],
-        "summary": "Update profile (full)",
-        "description": "Superset of PATCH — also accepts preferences and data_retention_days (min 30).",
-        "security": [{ "BearerAuth": [] }],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": { "type": "string" },
-                  "bio": { "type": "string" },
-                  "avatar_url": { "type": "string", "format": "uri" },
-                  "location": { "type": "string" },
-                  "website_url": { "type": "string", "format": "uri" },
-                  "preferences": {
-                    "type": "object",
-                    "additionalProperties": {}
-                  },
-                  "data_retention_days": { "type": "integer", "minimum": 30 }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile row",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/RawProfileResponse" }
-              }
-            }
-          },
-          "400": {
-            "description": "No fields provided, or data_retention_days < 30"
-          },
-          "401": { "description": "Unauthorized" }
-        }
-      }
-    },
-    "/api/v1/auth/account": {
-      "delete": {
-        "operationId": "deleteAccount",
-        "tags": ["Auth"],
-        "summary": "Delete account",
-        "security": [{ "BearerAuth": [] }],
-        "responses": {
-          "204": { "description": "Account deleted" },
-          "401": { "description": "Unauthorized" }
         }
       }
     },
@@ -824,7 +1072,11 @@
         "tags": ["Profiles"],
         "summary": "List available profiles",
         "description": "Returns all non-anonymous active profiles for the authenticated API key.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Available profiles",
@@ -833,11 +1085,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/ProfileSummary" }
+                      "items": {
+                        "$ref": "#/components/schemas/ProfileSummary"
+                      }
                     }
                   },
                   "required": ["ok", "success", "data"]
@@ -845,7 +1103,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -855,7 +1115,11 @@
         "tags": ["Profiles"],
         "summary": "Get active profile",
         "description": "Returns the default active (non-anonymous) profile for the authenticated API key.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Active profile",
@@ -864,16 +1128,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/ProfileSummary" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ProfileSummary"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -882,7 +1154,11 @@
         "operationId": "updateProfile",
         "tags": ["Profiles"],
         "summary": "Update a profile",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -901,10 +1177,20 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "profileName": { "type": "string", "minLength": 1 },
-                  "avatar": { "type": "string", "format": "uri" },
-                  "bio": { "type": ["string", "null"] },
-                  "location": { "type": ["string", "null"] }
+                  "profileName": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "avatar": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "bio": {
+                    "type": ["string", "null"]
+                  },
+                  "location": {
+                    "type": ["string", "null"]
+                  }
                 }
               }
             }
@@ -915,14 +1201,18 @@
             "description": "Profile updated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UpdatedProfile" }
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatedProfile"
+                }
               }
             }
           },
           "400": {
             "description": "Validation error — invalid profileId format or body"
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -932,7 +1222,11 @@
         "tags": ["Profiles"],
         "summary": "Activate a profile",
         "description": "Switches the active profile to the specified profile.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -953,12 +1247,18 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "activeProfile": { "type": "string" },
+                        "activeProfile": {
+                          "type": "string"
+                        },
                         "switchedAt": {
                           "type": "string",
                           "format": "date-time"
@@ -975,7 +1275,9 @@
           "400": {
             "description": "Validation error — invalid profileId format"
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -985,7 +1287,11 @@
         "tags": ["Groups"],
         "summary": "List groups",
         "description": "Returns all groups the authenticated user created or joined.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "User groups",
@@ -994,11 +1300,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/GroupSummary" }
+                      "items": {
+                        "$ref": "#/components/schemas/GroupSummary"
+                      }
                     }
                   },
                   "required": ["ok", "success", "data"]
@@ -1006,7 +1318,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1016,7 +1330,11 @@
         "tags": ["Groups"],
         "summary": "Get group members",
         "description": "Returns members of a group. Requires the caller to be the creator or a member.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1037,11 +1355,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/GroupMember" }
+                      "items": {
+                        "$ref": "#/components/schemas/GroupMember"
+                      }
                     }
                   },
                   "required": ["ok", "success", "data"]
@@ -1049,50 +1373,350 @@
               }
             }
           },
-          "400": { "description": "Validation error — invalid groupId format" },
-          "401": { "description": "Invalid or missing API key" },
-          "403": { "description": "Not a member or creator of this group" },
-          "404": { "description": "Group not found" }
+          "400": {
+            "description": "Validation error — invalid groupId format"
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
+          "403": {
+            "description": "Not a member or creator of this group"
+          },
+          "404": {
+            "description": "Group not found"
+          }
         }
       }
     },
-    "/api/v1/user/me": {
-      "get": {
-        "operationId": "getCurrentUser",
-        "tags": ["User"],
-        "summary": "Get current user",
-        "description": "Returns the authenticated user's active profile and API key metadata.",
-        "security": [{ "ApiKeyAuth": [] }],
+    "/api/v1/auth/register": {
+      "post": {
+        "operationId": "register",
+        "tags": ["Auth"],
+        "summary": "Register a new user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 8,
+                    "pattern": "[A-Z]"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  },
+                  "preferences": {}
+                },
+                "required": ["email", "password"]
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {
-            "description": "Current user",
+          "201": {
+            "description": "User registered and session created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserMe" }
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSessionResponse"
+                }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "400": {
+            "description": "Validation error — weak password or invalid email"
+          },
+          "409": {
+            "description": "Email already registered"
+          }
         }
       }
     },
-    "/api/v1/analytics/summary": {
-      "get": {
-        "operationId": "getAnalyticsSummary",
-        "tags": ["Analytics"],
-        "summary": "Get analytics summary",
-        "description": "Returns 7-day usage analytics for the authenticated API key.",
-        "security": [{ "ApiKeyAuth": [] }],
+    "/api/v1/auth/login": {
+      "post": {
+        "operationId": "login",
+        "tags": ["Auth"],
+        "summary": "Log in",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["email", "password"]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Analytics summary",
+            "description": "Login successful",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AnalyticsSummary" }
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSessionResponse"
+                }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "400": {
+            "description": "Validation error — missing email or password"
+          },
+          "401": {
+            "description": "Invalid credentials"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "operationId": "logout",
+        "tags": ["Auth"],
+        "summary": "Log out",
+        "description": "Invalidates the current session. Requires Authorization header.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Logged out"
+          },
+          "401": {
+            "description": "Missing authorization header"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/token/refresh": {
+      "post": {
+        "operationId": "refreshToken",
+        "tags": ["Auth"],
+        "summary": "Refresh access token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "refresh_token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["refresh_token"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "New tokens issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenRefreshResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error — missing refresh_token"
+          },
+          "401": {
+            "description": "Invalid or expired refresh token"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/profile": {
+      "get": {
+        "operationId": "getAuthProfile",
+        "tags": ["Auth"],
+        "summary": "Get auth profile",
+        "description": "Returns the authenticated user identity and API key metadata.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auth profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthProfileResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "patchAuthProfile",
+        "tags": ["Auth"],
+        "summary": "Update profile (partial)",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "avatar_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "website_url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated profile row",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RawProfileResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No fields provided"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putAuthProfile",
+        "tags": ["Auth"],
+        "summary": "Update profile (full)",
+        "description": "Superset of PATCH — also accepts preferences and data_retention_days (min 30).",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "avatar_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "website_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "preferences": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "data_retention_days": {
+                    "type": "integer",
+                    "minimum": 30
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated profile row",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RawProfileResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No fields provided, or data_retention_days < 30"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/account": {
+      "delete": {
+        "operationId": "deleteAccount",
+        "tags": ["Auth"],
+        "summary": "Delete account",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Account deleted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -1102,7 +1726,11 @@
         "tags": ["Sessions"],
         "summary": "List sessions",
         "description": "Returns the user's sessions. Sessions feature is not yet implemented — returns empty paginated list.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Sessions list (currently always empty)",
@@ -1111,33 +1739,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "type": "array", "items": {} },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {}
+                    },
                     "meta": {
                       "type": "object",
                       "properties": {
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
                       },
                       "required": ["pagination"]
                     },
-                    "message": { "type": "string" }
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "data", "meta"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1147,7 +1794,11 @@
         "tags": ["Sessions"],
         "summary": "List upcoming sessions",
         "description": "Returns upcoming sessions. Sessions feature is not yet implemented — returns empty list.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Upcoming sessions (currently always empty)",
@@ -1156,17 +1807,28 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "type": "array", "items": {} },
-                    "message": { "type": "string" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1176,7 +1838,11 @@
         "tags": ["Team"],
         "summary": "List team members",
         "description": "Returns group memberships for the authenticated user as a flat list of team members.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Team members",
@@ -1185,19 +1851,29 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/TeamMember" }
+                      "items": {
+                        "$ref": "#/components/schemas/TeamMember"
+                      }
                     },
                     "meta": {
                       "type": "object",
                       "properties": {
-                        "total": { "type": "integer" },
+                        "total": {
+                          "type": "integer"
+                        },
                         "roles": {
                           "type": "array",
-                          "items": { "type": "string" }
+                          "items": {
+                            "type": "string"
+                          }
                         }
                       },
                       "required": ["total", "roles"]
@@ -1208,7 +1884,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1218,28 +1896,43 @@
         "tags": ["Marketplace"],
         "summary": "Browse marketplace apps",
         "description": "Returns paginated list of approved, active marketplace apps.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 },
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
             "required": false,
             "name": "limit",
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "minimum": 0 },
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
             "required": false,
             "name": "offset",
             "in": "query"
           },
           {
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "name": "category",
             "in": "query"
           },
           {
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "name": "search",
             "in": "query"
@@ -1253,11 +1946,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/MarketplaceApp" }
+                      "items": {
+                        "$ref": "#/components/schemas/MarketplaceApp"
+                      }
                     },
                     "meta": {
                       "type": "object",
@@ -1265,10 +1964,18 @@
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
@@ -1281,7 +1988,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1291,7 +2000,11 @@
         "tags": ["Marketplace"],
         "summary": "Trending apps",
         "description": "Returns approved apps sorted by install count (top 20).",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Trending apps",
@@ -1300,11 +2013,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/MarketplaceApp" }
+                      "items": {
+                        "$ref": "#/components/schemas/MarketplaceApp"
+                      }
                     }
                   },
                   "required": ["ok", "success", "data"]
@@ -1312,7 +2031,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1322,7 +2043,11 @@
         "tags": ["Marketplace"],
         "summary": "Featured apps",
         "description": "Returns featured approved apps (curated subset of top apps).",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Featured apps",
@@ -1331,11 +2056,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/MarketplaceApp" }
+                      "items": {
+                        "$ref": "#/components/schemas/MarketplaceApp"
+                      }
                     }
                   },
                   "required": ["ok", "success", "data"]
@@ -1343,7 +2074,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1353,7 +2086,11 @@
         "tags": ["Marketplace"],
         "summary": "List app categories",
         "description": "Returns distinct categories from approved apps with their app counts. Note: a second registration of this path exists (no auth, collections-table version) but is shadowed by this route (Express first-match).",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Category counts",
@@ -1362,15 +2099,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
-                          "category": { "type": "string" },
-                          "count": { "type": "integer" }
+                          "category": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "integer"
+                          }
                         },
                         "required": ["category", "count"]
                       }
@@ -1381,7 +2126,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1390,10 +2137,17 @@
         "operationId": "getMarketplaceApp",
         "tags": ["Marketplace"],
         "summary": "Get app details",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -1407,17 +2161,27 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceApp" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceApp"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" },
-          "404": { "description": "App not found" }
+          "401": {
+            "description": "Invalid or missing API key"
+          },
+          "404": {
+            "description": "App not found"
+          }
         }
       }
     },
@@ -1427,16 +2191,27 @@
         "tags": ["Marketplace"],
         "summary": "List installed apps",
         "description": "Returns all apps installed by the authenticated user.",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 },
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
             "required": false,
             "name": "limit",
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "minimum": 0 },
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
             "required": false,
             "name": "offset",
             "in": "query"
@@ -1450,11 +2225,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/InstalledApp" }
+                      "items": {
+                        "$ref": "#/components/schemas/InstalledApp"
+                      }
                     },
                     "meta": {
                       "type": "object",
@@ -1462,10 +2243,18 @@
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
@@ -1478,7 +2267,9 @@
               }
             }
           },
-          "401": { "description": "Unauthorized" }
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -1487,10 +2278,17 @@
         "operationId": "installMarketplaceApp",
         "tags": ["Marketplace"],
         "summary": "Install app",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -1502,7 +2300,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "settings": { "type": "object", "additionalProperties": {} }
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
                 }
               }
             }
@@ -1516,21 +2317,33 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/InstalledApp" },
-                    "message": { "type": "string" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/InstalledApp"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "data", "message"]
                 }
               }
             }
           },
-          "401": { "description": "Unauthorized" },
+          "401": {
+            "description": "Unauthorized"
+          },
           "404": {
             "description": "App not found or not available for installation"
           },
-          "409": { "description": "App already installed" }
+          "409": {
+            "description": "App already installed"
+          }
         }
       }
     },
@@ -1539,10 +2352,17 @@
         "operationId": "uninstallMarketplaceApp",
         "tags": ["Marketplace"],
         "summary": "Uninstall app",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -1556,17 +2376,27 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "message"]
                 }
               }
             }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "App installation not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "App installation not found"
+          }
         }
       }
     },
@@ -1578,55 +2408,78 @@
         "description": "Public listing of published marketplace items (entry-based). No authentication required.",
         "parameters": [
           {
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 },
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
             "required": false,
             "name": "limit",
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "minimum": 0 },
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
             "required": false,
             "name": "offset",
             "in": "query"
           },
           {
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "name": "item_type",
             "in": "query"
           },
           {
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "name": "earner_type",
             "in": "query"
           },
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": false,
             "name": "category_id",
             "in": "query"
           },
           {
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "required": false,
             "name": "min_price",
             "in": "query"
           },
           {
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "required": false,
             "name": "max_price",
             "in": "query"
           },
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": false,
             "name": "seller_id",
             "in": "query"
           },
           {
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "name": "search",
             "in": "query"
@@ -1640,8 +2493,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
                       "items": {
@@ -1654,10 +2511,18 @@
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
@@ -1681,7 +2546,10 @@
         "description": "Returns a single published marketplace item by ID.",
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "id",
             "in": "path"
@@ -1695,16 +2563,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceItem" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceItem"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "404": { "description": "Item not found" }
+          "404": {
+            "description": "Item not found"
+          }
         }
       }
     },
@@ -1720,10 +2596,21 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "query": { "type": "string", "minLength": 1 },
-                  "filters": { "type": "object", "additionalProperties": {} },
-                  "limit": { "type": "integer", "maximum": 100 },
-                  "offset": { "type": "integer" }
+                  "query": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "filters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "maximum": 100
+                  },
+                  "offset": {
+                    "type": "integer"
+                  }
                 },
                 "required": ["query"]
               }
@@ -1738,8 +2625,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
                       "items": {
@@ -1752,10 +2643,18 @@
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
@@ -1785,13 +2684,19 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
                       "items": {
                         "allOf": [
-                          { "$ref": "#/components/schemas/Category" },
+                          {
+                            "$ref": "#/components/schemas/Category"
+                          },
                           {
                             "type": "object",
                             "properties": {
@@ -1824,7 +2729,10 @@
         "description": "Returns a single marketplace category from the collections table.",
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "id",
             "in": "path"
@@ -1838,16 +2746,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/Category" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Category"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "404": { "description": "Category not found" }
+          "404": {
+            "description": "Category not found"
+          }
         }
       }
     },
@@ -1857,7 +2773,11 @@
         "tags": ["Developer"],
         "summary": "List developer apps",
         "description": "Returns all marketplace apps owned by the authenticated developer.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Developer apps",
@@ -1866,11 +2786,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/MarketplaceApp" }
+                      "items": {
+                        "$ref": "#/components/schemas/MarketplaceApp"
+                      }
                     }
                   },
                   "required": ["ok", "success", "data"]
@@ -1878,39 +2804,72 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       },
       "post": {
         "operationId": "createDeveloperApp",
         "tags": ["Developer"],
         "summary": "Create app",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": { "type": "string", "minLength": 1 },
-                  "slug": { "type": "string", "minLength": 1 },
-                  "tagline": { "type": "string" },
-                  "description": { "type": "string" },
-                  "category": { "type": "string", "minLength": 1 },
-                  "icon_url": { "type": "string", "format": "uri" },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tagline": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "icon_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "screenshots": {
                     "type": "array",
-                    "items": { "type": "string", "format": "uri" }
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   },
-                  "version": { "type": "string", "default": "1.0.0" },
-                  "pricing_model": { "type": "string", "default": "free" },
+                  "version": {
+                    "type": "string",
+                    "default": "1.0.0"
+                  },
+                  "pricing_model": {
+                    "type": "string",
+                    "default": "free"
+                  },
                   "pricing_config": {
                     "type": "object",
                     "additionalProperties": {}
                   },
                   "supported_audience": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": ["name", "slug", "category"]
@@ -1926,16 +2885,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceApp" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceApp"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -1944,10 +2911,17 @@
         "operationId": "getDeveloperApp",
         "tags": ["Developer"],
         "summary": "Get developer app",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -1961,16 +2935,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceApp" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceApp"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
           "404": {
             "description": "App not found or not owned by this developer"
           }
@@ -1980,10 +2962,17 @@
         "operationId": "updateDeveloperApp",
         "tags": ["Developer"],
         "summary": "Update app",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -1995,25 +2984,49 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": { "type": "string", "minLength": 1 },
-                  "slug": { "type": "string", "minLength": 1 },
-                  "tagline": { "type": "string" },
-                  "description": { "type": "string" },
-                  "category": { "type": "string" },
-                  "icon_url": { "type": "string", "format": "uri" },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tagline": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "icon_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "screenshots": {
                     "type": "array",
-                    "items": { "type": "string", "format": "uri" }
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   },
-                  "version": { "type": "string" },
-                  "pricing_model": { "type": "string" },
+                  "version": {
+                    "type": "string"
+                  },
+                  "pricing_model": {
+                    "type": "string"
+                  },
                   "pricing_config": {
                     "type": "object",
                     "additionalProperties": {}
                   },
                   "supported_audience": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -2028,16 +3041,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceApp" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceApp"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
           "404": {
             "description": "App not found or not owned by this developer"
           }
@@ -2048,21 +3069,32 @@
         "tags": ["Developer"],
         "summary": "Delete app",
         "description": "Only draft apps can be deleted. Approved apps must be deactivated first.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
           }
         ],
         "responses": {
-          "204": { "description": "App deleted" },
+          "204": {
+            "description": "App deleted"
+          },
           "400": {
             "description": "App is not in draft status — cannot delete"
           },
-          "401": { "description": "Invalid or missing API key" },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
           "404": {
             "description": "App not found or not owned by this developer"
           }
@@ -2075,10 +3107,17 @@
         "tags": ["Developer"],
         "summary": "Submit app for review",
         "description": "Transitions app from draft → pending_review.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -2092,18 +3131,30 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceApp" },
-                    "message": { "type": "string" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceApp"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "data", "message"]
                 }
               }
             }
           },
-          "400": { "description": "App is not in draft status" },
-          "401": { "description": "Invalid or missing API key" },
+          "400": {
+            "description": "App is not in draft status"
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
           "404": {
             "description": "App not found or not owned by this developer"
           }
@@ -2116,10 +3167,17 @@
         "tags": ["Developer"],
         "summary": "Resubmit rejected app",
         "description": "Updates fields and resubmits a rejected app for review.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "appId",
             "in": "path"
@@ -2131,25 +3189,49 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": { "type": "string", "minLength": 1 },
-                  "slug": { "type": "string", "minLength": 1 },
-                  "tagline": { "type": "string" },
-                  "description": { "type": "string" },
-                  "category": { "type": "string" },
-                  "icon_url": { "type": "string", "format": "uri" },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tagline": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "icon_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "screenshots": {
                     "type": "array",
-                    "items": { "type": "string", "format": "uri" }
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   },
-                  "version": { "type": "string" },
-                  "pricing_model": { "type": "string" },
+                  "version": {
+                    "type": "string"
+                  },
+                  "pricing_model": {
+                    "type": "string"
+                  },
                   "pricing_config": {
                     "type": "object",
                     "additionalProperties": {}
                   },
                   "supported_audience": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -2164,18 +3246,30 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/MarketplaceApp" },
-                    "message": { "type": "string" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarketplaceApp"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "data", "message"]
                 }
               }
             }
           },
-          "400": { "description": "App is not in rejected status" },
-          "401": { "description": "Invalid or missing API key" },
+          "400": {
+            "description": "App is not in rejected status"
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
           "404": {
             "description": "App not found or not owned by this developer"
           }
@@ -2188,7 +3282,11 @@
         "tags": ["Entries"],
         "summary": "List entries",
         "description": "Returns paginated entries for the authenticated user's profile.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2202,7 +3300,11 @@
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "minimum": 0, "default": 0 },
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
             "required": false,
             "name": "offset",
             "in": "query"
@@ -2216,11 +3318,17 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Entry" }
+                      "items": {
+                        "$ref": "#/components/schemas/Entry"
+                      }
                     },
                     "meta": {
                       "type": "object",
@@ -2228,10 +3336,18 @@
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
@@ -2244,8 +3360,12 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" },
-          "404": { "description": "User profile not found" }
+          "401": {
+            "description": "Invalid or missing API key"
+          },
+          "404": {
+            "description": "User profile not found"
+          }
         }
       }
     },
@@ -2255,7 +3375,11 @@
         "tags": ["Entries"],
         "summary": "List templates",
         "description": "Returns available entry templates. Not yet implemented — returns empty list.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Templates list (currently always empty)",
@@ -2264,19 +3388,34 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "type": "array", "items": {} },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {}
+                    },
                     "meta": {
                       "type": "object",
                       "properties": {
                         "pagination": {
                           "type": "object",
                           "properties": {
-                            "page": { "type": "integer" },
-                            "limit": { "type": "integer" },
-                            "total": { "type": "integer" },
-                            "totalPages": { "type": "integer" }
+                            "page": {
+                              "type": "integer"
+                            },
+                            "limit": {
+                              "type": "integer"
+                            },
+                            "total": {
+                              "type": "integer"
+                            },
+                            "totalPages": {
+                              "type": "integer"
+                            }
                           },
                           "required": ["page", "limit", "total", "totalPages"]
                         }
@@ -2289,7 +3428,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -2299,7 +3440,11 @@
         "tags": ["Entries"],
         "summary": "Get storage info",
         "description": "Returns storage usage for the authenticated user. Not yet implemented — returns empty object.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Storage info",
@@ -2308,16 +3453,25 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "type": "object", "additionalProperties": {} }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -2327,7 +3481,11 @@
         "tags": ["UI"],
         "summary": "Create notification",
         "description": "Creates a UI notification for the authenticated user.",
-        "security": [{ "ApiKeyAuth": [] }],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Notification created",
@@ -2336,11 +3494,19 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "object",
-                      "properties": { "id": { "type": "string" } },
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      },
                       "required": ["id"]
                     }
                   },
@@ -2349,7 +3515,9 @@
               }
             }
           },
-          "401": { "description": "Invalid or missing API key" }
+          "401": {
+            "description": "Invalid or missing API key"
+          }
         }
       }
     },
@@ -2361,31 +3529,47 @@
         "description": "Returns active events with optional filtering by category and date range.",
         "parameters": [
           {
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "name": "category",
             "in": "query"
           },
           {
-            "schema": { "type": "string", "format": "date-time" },
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
             "required": false,
             "name": "startDate",
             "in": "query"
           },
           {
-            "schema": { "type": "string", "format": "date-time" },
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
             "required": false,
             "name": "endDate",
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "maximum": 100, "default": 20 },
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "default": 20
+            },
             "required": false,
             "name": "limit",
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "minimum": 0, "default": 0 },
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
             "required": false,
             "name": "offset",
             "in": "query"
@@ -2399,15 +3583,27 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Event" }
+                      "items": {
+                        "$ref": "#/components/schemas/Event"
+                      }
                     },
-                    "total": { "type": "integer" },
-                    "limit": { "type": "integer" },
-                    "offset": { "type": "integer" }
+                    "total": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "type": "integer"
+                    }
                   },
                   "required": [
                     "ok",
@@ -2427,31 +3623,62 @@
         "operationId": "createEvent",
         "tags": ["Events"],
         "summary": "Create event",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "title": { "type": "string", "minLength": 1 },
-                  "description": { "type": "string", "minLength": 1 },
-                  "startDate": { "type": "string", "format": "date-time" },
-                  "endDate": { "type": "string", "format": "date-time" },
-                  "isOnline": { "type": "boolean" },
-                  "category": { "type": "string", "minLength": 1 },
-                  "location": { "type": ["string", "null"] },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "isOnline": {
+                    "type": "boolean"
+                  },
+                  "category": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "location": {
+                    "type": ["string", "null"]
+                  },
                   "maxAttendees": {
                     "type": ["integer", "null"],
                     "exclusiveMinimum": 0
                   },
-                  "price": { "type": "number", "minimum": 0 },
+                  "price": {
+                    "type": "number",
+                    "minimum": 0
+                  },
                   "tags": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": {
+                      "type": "string"
+                    },
                     "maxItems": 20
                   },
-                  "imageUrl": { "type": ["string", "null"], "format": "uri" }
+                  "imageUrl": {
+                    "type": ["string", "null"],
+                    "format": "uri"
+                  }
                 },
                 "required": [
                   "title",
@@ -2473,10 +3700,18 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/Event" },
-                    "message": { "type": "string" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Event"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
                   "required": ["ok", "success", "data", "message"]
                 }
@@ -2486,7 +3721,9 @@
           "400": {
             "description": "Validation error — missing required fields or invalid category"
           },
-          "401": { "description": "Unauthorized" }
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -2497,7 +3734,10 @@
         "summary": "Get event",
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "eventId",
             "in": "path"
@@ -2511,16 +3751,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": { "type": "boolean" },
-                    "success": { "type": "boolean" },
-                    "data": { "$ref": "#/components/schemas/Event" }
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Event"
+                    }
                   },
                   "required": ["ok", "success", "data"]
                 }
               }
             }
           },
-          "404": { "description": "Event not found" }
+          "404": {
+            "description": "Event not found"
+          }
         }
       }
     },
@@ -2530,7 +3778,11 @@
         "tags": ["PersonalTokens"],
         "summary": "Create a Personal Access Token",
         "description": "Issues a new Personal Access Token (PAT) scoped to the authenticated account. The full token value is returned **once** and cannot be retrieved again. PATs carry broad `[\"read\",\"write\"]` permissions and are intended for personal tooling (e.g. MCP servers).",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2566,8 +3818,12 @@
               }
             }
           },
-          "400": { "description": "Validation error" },
-          "401": { "description": "Not authenticated" }
+          "400": {
+            "description": "Validation error"
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
         }
       },
       "get": {
@@ -2575,17 +3831,25 @@
         "tags": ["PersonalTokens"],
         "summary": "List Personal Access Tokens",
         "description": "Returns all PATs belonging to the authenticated account. Full token values and hashes are never returned.",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of PATs",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PersonalTokenList" }
+                "schema": {
+                  "$ref": "#/components/schemas/PersonalTokenList"
+                }
               }
             }
           },
-          "401": { "description": "Not authenticated" }
+          "401": {
+            "description": "Not authenticated"
+          }
         }
       }
     },
@@ -2595,18 +3859,29 @@
         "tags": ["PersonalTokens"],
         "summary": "Revoke a Personal Access Token",
         "description": "Sets `is_active = false` on the token (soft-delete). The row is preserved for audit purposes. Returns 404 if the token does not belong to this account.",
-        "security": [{ "BearerAuth": [] }],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "required": true,
             "name": "id",
             "in": "path"
           }
         ],
         "responses": {
-          "204": { "description": "Revoked successfully" },
-          "401": { "description": "Not authenticated" },
+          "204": {
+            "description": "Revoked successfully"
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
           "404": {
             "description": "Token not found or does not belong to this account"
           }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Spec-driven CLI for the Oriva public API. Every endpoint is a subcommand — no Node code required to call the API.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build && npm test"
   },
   "peerDependencies": {
-    "@oriva/sdk": "0.1.x"
+    "@oriva/sdk": "0.1.x || 0.2.x"
   },
   "peerDependenciesMeta": {
     "@oriva/sdk": {

--- a/packages/cli/scripts/copy-spec.mjs
+++ b/packages/cli/scripts/copy-spec.mjs
@@ -21,14 +21,19 @@ const pkgRoot = resolve(here, '..');
 const src = resolve(pkgRoot, '..', '..', 'claudedocs', 'openapi-snapshot.json');
 const dst = resolve(pkgRoot, 'openapi-snapshot.json');
 
-const spec = JSON.parse(readFileSync(src, 'utf8'));
+// Verbatim copy of the canonical file. The canonical is Prettier-formatted
+// (printWidth:80, compact short arrays), and the CLI does not filter operations
+// (unlike packages/mcp-server which drops PAT ops). Verbatim copy guarantees
+// byte-for-byte match, which lets cli-ci.yml drift-guard catch uncommitted
+// regenerations of the canonical snapshot.
+const raw = readFileSync(src, 'utf8');
+writeFileSync(dst, raw);
 
+const spec = JSON.parse(raw);
 let opCount = 0;
 for (const pathItem of Object.values(spec.paths ?? {})) {
   for (const method of Object.keys(pathItem)) {
     if (['get', 'post', 'put', 'patch', 'delete'].includes(method)) opCount += 1;
   }
 }
-
-writeFileSync(dst, JSON.stringify(spec));
 console.log(`[copy-spec] ${src} -> ${dst} (${opCount} operations)`);

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Model Context Protocol server for the Oriva public API. Exposes all 46 public endpoints as MCP tools for use in Claude Code, Cursor, Continue, and Claude Desktop.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Typed TypeScript SDK for the Oriva public API. Generated from the OpenAPI v3 spec.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/generated/sdk.gen.ts
+++ b/packages/sdk/src/generated/sdk.gen.ts
@@ -167,6 +167,124 @@ export type Options<
 };
 
 /**
+ * Get current user
+ *
+ * Returns the authenticated user's active profile and API key metadata.
+ */
+export const getCurrentUser = <ThrowOnError extends boolean = false>(
+  options?: Options<GetCurrentUserData, ThrowOnError>
+) =>
+  (options?.client ?? client).get<GetCurrentUserResponses, GetCurrentUserErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/user/me',
+    ...options,
+  });
+
+/**
+ * Get analytics summary
+ *
+ * Returns 7-day usage analytics for the authenticated API key.
+ */
+export const getAnalyticsSummary = <ThrowOnError extends boolean = false>(
+  options?: Options<GetAnalyticsSummaryData, ThrowOnError>
+) =>
+  (options?.client ?? client).get<
+    GetAnalyticsSummaryResponses,
+    GetAnalyticsSummaryErrors,
+    ThrowOnError
+  >({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/analytics/summary',
+    ...options,
+  });
+
+/**
+ * List available profiles
+ *
+ * Returns all non-anonymous active profiles for the authenticated API key.
+ */
+export const listProfiles = <ThrowOnError extends boolean = false>(
+  options?: Options<ListProfilesData, ThrowOnError>
+) =>
+  (options?.client ?? client).get<ListProfilesResponses, ListProfilesErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/profiles/available',
+    ...options,
+  });
+
+/**
+ * Get active profile
+ *
+ * Returns the default active (non-anonymous) profile for the authenticated API key.
+ */
+export const getActiveProfile = <ThrowOnError extends boolean = false>(
+  options?: Options<GetActiveProfileData, ThrowOnError>
+) =>
+  (options?.client ?? client).get<GetActiveProfileResponses, GetActiveProfileErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/profiles/active',
+    ...options,
+  });
+
+/**
+ * Update a profile
+ */
+export const updateProfile = <ThrowOnError extends boolean = false>(
+  options: Options<UpdateProfileData, ThrowOnError>
+) =>
+  (options.client ?? client).put<UpdateProfileResponses, UpdateProfileErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/profiles/{profileId}',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+/**
+ * Activate a profile
+ *
+ * Switches the active profile to the specified profile.
+ */
+export const activateProfile = <ThrowOnError extends boolean = false>(
+  options: Options<ActivateProfileData, ThrowOnError>
+) =>
+  (options.client ?? client).post<ActivateProfileResponses, ActivateProfileErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/profiles/{profileId}/activate',
+    ...options,
+  });
+
+/**
+ * List groups
+ *
+ * Returns all groups the authenticated user created or joined.
+ */
+export const listGroups = <ThrowOnError extends boolean = false>(
+  options?: Options<ListGroupsData, ThrowOnError>
+) =>
+  (options?.client ?? client).get<ListGroupsResponses, ListGroupsErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/groups',
+    ...options,
+  });
+
+/**
+ * Get group members
+ *
+ * Returns members of a group. Requires the caller to be the creator or a member.
+ */
+export const listGroupMembers = <ThrowOnError extends boolean = false>(
+  options: Options<ListGroupMembersData, ThrowOnError>
+) =>
+  (options.client ?? client).get<ListGroupMembersResponses, ListGroupMembersErrors, ThrowOnError>({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/v1/groups/{groupId}/members',
+    ...options,
+  });
+
+/**
  * Register a new user
  */
 export const register = <ThrowOnError extends boolean = false>(
@@ -289,124 +407,6 @@ export const deleteAccount = <ThrowOnError extends boolean = false>(
   (options?.client ?? client).delete<DeleteAccountResponses, DeleteAccountErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
     url: '/api/v1/auth/account',
-    ...options,
-  });
-
-/**
- * List available profiles
- *
- * Returns all non-anonymous active profiles for the authenticated API key.
- */
-export const listProfiles = <ThrowOnError extends boolean = false>(
-  options?: Options<ListProfilesData, ThrowOnError>
-) =>
-  (options?.client ?? client).get<ListProfilesResponses, ListProfilesErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/profiles/available',
-    ...options,
-  });
-
-/**
- * Get active profile
- *
- * Returns the default active (non-anonymous) profile for the authenticated API key.
- */
-export const getActiveProfile = <ThrowOnError extends boolean = false>(
-  options?: Options<GetActiveProfileData, ThrowOnError>
-) =>
-  (options?.client ?? client).get<GetActiveProfileResponses, GetActiveProfileErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/profiles/active',
-    ...options,
-  });
-
-/**
- * Update a profile
- */
-export const updateProfile = <ThrowOnError extends boolean = false>(
-  options: Options<UpdateProfileData, ThrowOnError>
-) =>
-  (options.client ?? client).put<UpdateProfileResponses, UpdateProfileErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/profiles/{profileId}',
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
-
-/**
- * Activate a profile
- *
- * Switches the active profile to the specified profile.
- */
-export const activateProfile = <ThrowOnError extends boolean = false>(
-  options: Options<ActivateProfileData, ThrowOnError>
-) =>
-  (options.client ?? client).post<ActivateProfileResponses, ActivateProfileErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/profiles/{profileId}/activate',
-    ...options,
-  });
-
-/**
- * List groups
- *
- * Returns all groups the authenticated user created or joined.
- */
-export const listGroups = <ThrowOnError extends boolean = false>(
-  options?: Options<ListGroupsData, ThrowOnError>
-) =>
-  (options?.client ?? client).get<ListGroupsResponses, ListGroupsErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/groups',
-    ...options,
-  });
-
-/**
- * Get group members
- *
- * Returns members of a group. Requires the caller to be the creator or a member.
- */
-export const listGroupMembers = <ThrowOnError extends boolean = false>(
-  options: Options<ListGroupMembersData, ThrowOnError>
-) =>
-  (options.client ?? client).get<ListGroupMembersResponses, ListGroupMembersErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/groups/{groupId}/members',
-    ...options,
-  });
-
-/**
- * Get current user
- *
- * Returns the authenticated user's active profile and API key metadata.
- */
-export const getCurrentUser = <ThrowOnError extends boolean = false>(
-  options?: Options<GetCurrentUserData, ThrowOnError>
-) =>
-  (options?.client ?? client).get<GetCurrentUserResponses, GetCurrentUserErrors, ThrowOnError>({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/user/me',
-    ...options,
-  });
-
-/**
- * Get analytics summary
- *
- * Returns 7-day usage analytics for the authenticated API key.
- */
-export const getAnalyticsSummary = <ThrowOnError extends boolean = false>(
-  options?: Options<GetAnalyticsSummaryData, ThrowOnError>
-) =>
-  (options?.client ?? client).get<
-    GetAnalyticsSummaryResponses,
-    GetAnalyticsSummaryErrors,
-    ThrowOnError
-  >({
-    security: [{ scheme: 'bearer', type: 'http' }],
-    url: '/api/v1/analytics/summary',
     ...options,
   });
 

--- a/packages/sdk/src/generated/types.gen.ts
+++ b/packages/sdk/src/generated/types.gen.ts
@@ -4,95 +4,6 @@ export type ClientOptions = {
   baseUrl: 'https://api.oriva.io' | 'http://localhost:3002' | (string & {});
 };
 
-export type AuthSessionResponse = {
-  user: {
-    id: string;
-    email: string | null;
-    display_name: string | null;
-    username: string | null;
-    subscription_tier: string;
-    created_at: string;
-  };
-  access_token: string;
-  refresh_token: string;
-  expires_in: number;
-};
-
-export type AuthProfileResponse = {
-  ok: boolean;
-  success: boolean;
-  data: {
-    id: string;
-    email: string | null;
-    displayName: string;
-    avatar: string | null;
-    authType: string;
-    permissions: Array<string>;
-    lastLogin: string;
-    accountStatus: string;
-    twoFactorEnabled: boolean;
-    emailVerified: boolean;
-  };
-};
-
-export type RawProfileResponse = {
-  id: string;
-  display_name: string | null;
-  username: string | null;
-  bio: string | null;
-  avatar_url: string | null;
-  location: string | null;
-  website_url: string | null;
-};
-
-export type TokenRefreshResponse = {
-  access_token: string;
-  refresh_token: string;
-  expires_in: number;
-};
-
-export type ProfileSummary = {
-  profileId: string;
-  profileName: string;
-  isActive: boolean;
-  avatar: string | null;
-  isDefault: boolean;
-};
-
-export type UpdatedProfile = {
-  ok: boolean;
-  success: boolean;
-  data: {
-    profileId: string;
-    profileName: string;
-    isActive: boolean;
-    avatar: string | null;
-    bio: string | null;
-    location: string | null;
-    updatedAt: string;
-  };
-  message?: string;
-};
-
-export type GroupSummary = {
-  groupId: string;
-  groupName: string;
-  memberCount: number;
-  isActive: boolean;
-  role: string;
-  description: string | null;
-  image_url: string | null;
-  external_link: string | null;
-};
-
-export type GroupMember = {
-  memberId: string;
-  displayName: string;
-  role: string;
-  joinedAt: string;
-  avatar: string | null;
-};
-
 export type UserMe = {
   ok: boolean;
   success: boolean;
@@ -140,6 +51,95 @@ export type AnalyticsSummary = {
     };
   };
   message?: string;
+};
+
+export type ProfileSummary = {
+  profileId: string;
+  profileName: string;
+  isActive: boolean;
+  avatar: string | null;
+  isDefault: boolean;
+};
+
+export type UpdatedProfile = {
+  ok: boolean;
+  success: boolean;
+  data: {
+    profileId: string;
+    profileName: string;
+    isActive: boolean;
+    avatar: string | null;
+    bio: string | null;
+    location: string | null;
+    updatedAt: string;
+  };
+  message?: string;
+};
+
+export type GroupSummary = {
+  groupId: string;
+  groupName: string;
+  memberCount: number;
+  isActive: boolean;
+  role: string;
+  description: string | null;
+  image_url: string | null;
+  external_link: string | null;
+};
+
+export type GroupMember = {
+  memberId: string;
+  displayName: string;
+  role: string;
+  joinedAt: string;
+  avatar: string | null;
+};
+
+export type AuthSessionResponse = {
+  user: {
+    id: string;
+    email: string | null;
+    display_name: string | null;
+    username: string | null;
+    subscription_tier: string;
+    created_at: string;
+  };
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+};
+
+export type AuthProfileResponse = {
+  ok: boolean;
+  success: boolean;
+  data: {
+    id: string;
+    email: string | null;
+    displayName: string;
+    avatar: string | null;
+    authType: string;
+    permissions: Array<string>;
+    lastLogin: string;
+    accountStatus: string;
+    twoFactorEnabled: boolean;
+    emailVerified: boolean;
+  };
+};
+
+export type RawProfileResponse = {
+  id: string;
+  display_name: string | null;
+  username: string | null;
+  bio: string | null;
+  avatar_url: string | null;
+  location: string | null;
+  website_url: string | null;
+};
+
+export type TokenRefreshResponse = {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
 };
 
 export type TeamMember = {
@@ -278,6 +278,245 @@ export type PersonalTokenList = {
   success: true;
   data: Array<PersonalTokenSummary>;
 };
+
+export type GetCurrentUserData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/api/v1/user/me';
+};
+
+export type GetCurrentUserErrors = {
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type GetCurrentUserResponses = {
+  /**
+   * Current user
+   */
+  200: UserMe;
+};
+
+export type GetCurrentUserResponse = GetCurrentUserResponses[keyof GetCurrentUserResponses];
+
+export type GetAnalyticsSummaryData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/api/v1/analytics/summary';
+};
+
+export type GetAnalyticsSummaryErrors = {
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type GetAnalyticsSummaryResponses = {
+  /**
+   * Analytics summary
+   */
+  200: AnalyticsSummary;
+};
+
+export type GetAnalyticsSummaryResponse =
+  GetAnalyticsSummaryResponses[keyof GetAnalyticsSummaryResponses];
+
+export type ListProfilesData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/api/v1/profiles/available';
+};
+
+export type ListProfilesErrors = {
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type ListProfilesResponses = {
+  /**
+   * Available profiles
+   */
+  200: {
+    ok: boolean;
+    success: boolean;
+    data: Array<ProfileSummary>;
+  };
+};
+
+export type ListProfilesResponse = ListProfilesResponses[keyof ListProfilesResponses];
+
+export type GetActiveProfileData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/api/v1/profiles/active';
+};
+
+export type GetActiveProfileErrors = {
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type GetActiveProfileResponses = {
+  /**
+   * Active profile
+   */
+  200: {
+    ok: boolean;
+    success: boolean;
+    data: ProfileSummary;
+  };
+};
+
+export type GetActiveProfileResponse = GetActiveProfileResponses[keyof GetActiveProfileResponses];
+
+export type UpdateProfileData = {
+  body?: {
+    profileName?: string;
+    avatar?: string;
+    bio?: string | null;
+    location?: string | null;
+  };
+  path: {
+    profileId: string;
+  };
+  query?: never;
+  url: '/api/v1/profiles/{profileId}';
+};
+
+export type UpdateProfileErrors = {
+  /**
+   * Validation error — invalid profileId format or body
+   */
+  400: unknown;
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type UpdateProfileResponses = {
+  /**
+   * Profile updated
+   */
+  200: UpdatedProfile;
+};
+
+export type UpdateProfileResponse = UpdateProfileResponses[keyof UpdateProfileResponses];
+
+export type ActivateProfileData = {
+  body?: never;
+  path: {
+    profileId: string;
+  };
+  query?: never;
+  url: '/api/v1/profiles/{profileId}/activate';
+};
+
+export type ActivateProfileErrors = {
+  /**
+   * Validation error — invalid profileId format
+   */
+  400: unknown;
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type ActivateProfileResponses = {
+  /**
+   * Profile activated
+   */
+  200: {
+    ok: boolean;
+    success: boolean;
+    data: {
+      activeProfile: string;
+      switchedAt: string;
+    };
+  };
+};
+
+export type ActivateProfileResponse = ActivateProfileResponses[keyof ActivateProfileResponses];
+
+export type ListGroupsData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/api/v1/groups';
+};
+
+export type ListGroupsErrors = {
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+};
+
+export type ListGroupsResponses = {
+  /**
+   * User groups
+   */
+  200: {
+    ok: boolean;
+    success: boolean;
+    data: Array<GroupSummary>;
+  };
+};
+
+export type ListGroupsResponse = ListGroupsResponses[keyof ListGroupsResponses];
+
+export type ListGroupMembersData = {
+  body?: never;
+  path: {
+    groupId: string;
+  };
+  query?: never;
+  url: '/api/v1/groups/{groupId}/members';
+};
+
+export type ListGroupMembersErrors = {
+  /**
+   * Validation error — invalid groupId format
+   */
+  400: unknown;
+  /**
+   * Invalid or missing API key
+   */
+  401: unknown;
+  /**
+   * Not a member or creator of this group
+   */
+  403: unknown;
+  /**
+   * Group not found
+   */
+  404: unknown;
+};
+
+export type ListGroupMembersResponses = {
+  /**
+   * Group members
+   */
+  200: {
+    ok: boolean;
+    success: boolean;
+    data: Array<GroupMember>;
+  };
+};
+
+export type ListGroupMembersResponse = ListGroupMembersResponses[keyof ListGroupMembersResponses];
 
 export type RegisterData = {
   body?: {
@@ -509,245 +748,6 @@ export type DeleteAccountResponses = {
 };
 
 export type DeleteAccountResponse = DeleteAccountResponses[keyof DeleteAccountResponses];
-
-export type ListProfilesData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/api/v1/profiles/available';
-};
-
-export type ListProfilesErrors = {
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type ListProfilesResponses = {
-  /**
-   * Available profiles
-   */
-  200: {
-    ok: boolean;
-    success: boolean;
-    data: Array<ProfileSummary>;
-  };
-};
-
-export type ListProfilesResponse = ListProfilesResponses[keyof ListProfilesResponses];
-
-export type GetActiveProfileData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/api/v1/profiles/active';
-};
-
-export type GetActiveProfileErrors = {
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type GetActiveProfileResponses = {
-  /**
-   * Active profile
-   */
-  200: {
-    ok: boolean;
-    success: boolean;
-    data: ProfileSummary;
-  };
-};
-
-export type GetActiveProfileResponse = GetActiveProfileResponses[keyof GetActiveProfileResponses];
-
-export type UpdateProfileData = {
-  body?: {
-    profileName?: string;
-    avatar?: string;
-    bio?: string | null;
-    location?: string | null;
-  };
-  path: {
-    profileId: string;
-  };
-  query?: never;
-  url: '/api/v1/profiles/{profileId}';
-};
-
-export type UpdateProfileErrors = {
-  /**
-   * Validation error — invalid profileId format or body
-   */
-  400: unknown;
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type UpdateProfileResponses = {
-  /**
-   * Profile updated
-   */
-  200: UpdatedProfile;
-};
-
-export type UpdateProfileResponse = UpdateProfileResponses[keyof UpdateProfileResponses];
-
-export type ActivateProfileData = {
-  body?: never;
-  path: {
-    profileId: string;
-  };
-  query?: never;
-  url: '/api/v1/profiles/{profileId}/activate';
-};
-
-export type ActivateProfileErrors = {
-  /**
-   * Validation error — invalid profileId format
-   */
-  400: unknown;
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type ActivateProfileResponses = {
-  /**
-   * Profile activated
-   */
-  200: {
-    ok: boolean;
-    success: boolean;
-    data: {
-      activeProfile: string;
-      switchedAt: string;
-    };
-  };
-};
-
-export type ActivateProfileResponse = ActivateProfileResponses[keyof ActivateProfileResponses];
-
-export type ListGroupsData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/api/v1/groups';
-};
-
-export type ListGroupsErrors = {
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type ListGroupsResponses = {
-  /**
-   * User groups
-   */
-  200: {
-    ok: boolean;
-    success: boolean;
-    data: Array<GroupSummary>;
-  };
-};
-
-export type ListGroupsResponse = ListGroupsResponses[keyof ListGroupsResponses];
-
-export type ListGroupMembersData = {
-  body?: never;
-  path: {
-    groupId: string;
-  };
-  query?: never;
-  url: '/api/v1/groups/{groupId}/members';
-};
-
-export type ListGroupMembersErrors = {
-  /**
-   * Validation error — invalid groupId format
-   */
-  400: unknown;
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-  /**
-   * Not a member or creator of this group
-   */
-  403: unknown;
-  /**
-   * Group not found
-   */
-  404: unknown;
-};
-
-export type ListGroupMembersResponses = {
-  /**
-   * Group members
-   */
-  200: {
-    ok: boolean;
-    success: boolean;
-    data: Array<GroupMember>;
-  };
-};
-
-export type ListGroupMembersResponse = ListGroupMembersResponses[keyof ListGroupMembersResponses];
-
-export type GetCurrentUserData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/api/v1/user/me';
-};
-
-export type GetCurrentUserErrors = {
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type GetCurrentUserResponses = {
-  /**
-   * Current user
-   */
-  200: UserMe;
-};
-
-export type GetCurrentUserResponse = GetCurrentUserResponses[keyof GetCurrentUserResponses];
-
-export type GetAnalyticsSummaryData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/api/v1/analytics/summary';
-};
-
-export type GetAnalyticsSummaryErrors = {
-  /**
-   * Invalid or missing API key
-   */
-  401: unknown;
-};
-
-export type GetAnalyticsSummaryResponses = {
-  /**
-   * Analytics summary
-   */
-  200: AnalyticsSummary;
-};
-
-export type GetAnalyticsSummaryResponse =
-  GetAnalyticsSummaryResponses[keyof GetAnalyticsSummaryResponses];
 
 export type ListSessionsData = {
   body?: never;

--- a/scripts/regen-openapi-snapshot.ts
+++ b/scripts/regen-openapi-snapshot.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env ts-node
+/**
+ * Regenerate the canonical OpenAPI snapshot from Zod schemas.
+ *
+ * Run after adding/modifying any path in src/openapi/schemas/*.ts.
+ * The CLI bundled snapshot (packages/cli/openapi-snapshot.json) and the
+ * MCP server's filtered spec.json are derived from this canonical file
+ * via packages/{cli,mcp-server}/scripts/copy-spec.mjs.
+ *
+ * Usage: npx ts-node scripts/regen-openapi-snapshot.ts
+ *
+ * Note: output is pretty-printed (2-space indent) to match Prettier's
+ * JSON format with printWidth:80. After writing, the CLI copy-spec.mjs
+ * pretty-prints with the same indent, so byte-for-byte comparison works.
+ */
+import { openApiDocument } from '../src/openapi/spec';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const dst = path.resolve(__dirname, '..', 'claudedocs', 'openapi-snapshot.json');
+const json = JSON.stringify(openApiDocument, null, 2) + '\n';
+fs.writeFileSync(dst, json);
+
+let opCount = 0;
+for (const pathItem of Object.values(openApiDocument.paths ?? {})) {
+  for (const method of Object.keys(pathItem as object)) {
+    if (['get', 'post', 'put', 'patch', 'delete'].includes(method)) opCount += 1;
+  }
+}
+console.log(`[regen-snapshot] wrote ${dst} (${opCount} operations)`);


### PR DESCRIPTION
## Summary

First real end-to-end test of the spec → SDK → CLI → MCP auto-cascade documented in \`api/patterns/oriva-sdk-pattern.md\`. Brings 3 PersonalAccessToken operations (already in \`src/openapi/schemas/me-tokens.ts\`) into the canonical OpenAPI snapshot, then cascades through SDK regeneration, CLI bundle refresh, and MCP spec projection.

If this PR ships green, the cascade architecture is proven for every future endpoint.

## Cascade verification

| Surface | Before | After | Filter |
|---|---|---|---|
| \`claudedocs/openapi-snapshot.json\` (canonical) | 46 ops | **49 ops** | none |
| \`packages/sdk/src/generated/\` | 46 ops | **49 ops** | none — typed PAT functions added |
| \`packages/cli/openapi-snapshot.json\` (bundled) | 49 ops (stale, manual) | **49 ops** (now byte-identical to canonical) | none |
| \`packages/mcp-server/src/spec.json\` (projected) | 46 ops | **46 ops** | PAT ops correctly hidden via \`MCP_HIDDEN_OPERATION_IDS\` |

## What ships in this PR

- \`scripts/regen-openapi-snapshot.ts\` — new canonical regen script (the missing piece for step 2 of the documented cascade)
- \`packages/sdk\`: 0.1.0 → 0.2.0 (regenerated includes \`createPersonalAccessToken\`, \`listPersonalAccessTokens\`, \`revokePersonalAccessToken\` typed functions)
- \`packages/cli\`: 0.1.0 → 0.1.1 — \`copy-spec.mjs\` switched from \`JSON.stringify\` to verbatim byte-copy. Sidesteps the Prettier-vs-stringify formatting mismatch from v0.1.0; drift-guard byte-comparison now works
- \`packages/mcp-server\`: 0.3.0 → 0.3.1 (spec.json refreshed; PAT filtering verified intact)
- \`.github/workflows/cli-ci.yml\`: drift-guard step **re-enabled** (closes the v0.1.0 deferred item documented in \`ORIVA_CLI_AND_MCP_CLI_SHELLOUT_MAY16_2026\`)

## Test plan

- [x] SDK: \`npx tsc --noEmit\` clean; \`npm pack --dry-run\` → 56 files, 37.5 kB
- [x] CLI: 60/60 jest tests pass; drift-guard byte-match confirmed (`diff packages/cli/openapi-snapshot.json claudedocs/openapi-snapshot.json` exits 0)
- [x] MCP: 21/21 jest tests pass; verified PAT ops correctly hidden (46 projected ops, not 49)

## Auto-publish on merge

All three packages auto-publish via CI on merge. NPM_TOKEN is now Granular Automation (rotated 2026-05-16, 2FA-bypass enabled). No manual \`npm publish\` needed for any of them.

## Why this matters

This is the moment that proves the architecture. If the cascade works clean end-to-end here, every future endpoint addition becomes: write Zod schema → run regen-script → commit → merge → all three packages auto-publish. That's the compounding infrastructure win the CLI + MCP refactor was designed for.