### PR TITLE
chore(cascade): correct CLI 0.2.1 / MCP 0.4.1 above npm registry state

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/cli",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "description": "Spec-driven CLI for the Oriva public API. Every endpoint is a subcommand \u2014 no Node code required to call the API.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/mcp-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Model Context Protocol server for the Oriva public API. Exposes all 46 public endpoints as MCP tools for use in Claude Code, Cursor, Continue, and Claude Desktop.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## User Story

**As a** future contributor publishing @oriva/cli or @oriva/mcp-server,
**I want to** read the source-of-truth version in package.json,
**So I can** bump correctly without colliding with npm's registry state.

## Standards

- In-source version MUST be > latest published version on npm
- Mechanical bump only; no code changes

## User Criteria

- [x] @oriva/cli source bumped 0.1.2 → 0.2.1 (above npm's 0.2.0)
- [x] @oriva/mcp-server source bumped 0.4.0 → 0.4.1 (above npm's 0.4.0)
- [x] @oriva/sdk already at 0.3.0 in source; matches successful npm publish from PR #41

## Tech Criteria

- [x] No code changes — version bumps only
- [x] No regen / cascade re-run needed (snapshots in source already include createPaymentLink from PR #40)

## Sketch Ideas

PR #41 bumped CLI 0.1.1→0.1.2 and MCP 0.3.1→0.4.0. But npm registry showed CLI 0.2.0 and MCP 0.4.0 published 2026-05-18 00:31 UTC (origin unclear — appears to be a prior cascade event). Correcting in-source above the registry state.

## Skills to consult

- (none — mechanical version correction)

## Enhance existing approach

- [x] Prefer extending existing code/patterns over creating new abstractions

---

**Co-Authored-By:** Claude Opus 4.7 (1M context) <noreply@anthropic.com>