### PR TITLE
fix(cli): widen @oriva/sdk peer range to include 0.3.x (unblock Vercel)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Spec-driven CLI for the Oriva public API. Every endpoint is a subcommand \u2014 no Node code required to call the API.",
   "license": "MIT",
   "type": "module",
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build && npm test"
   },
   "peerDependencies": {
-    "@oriva/sdk": "0.1.x || 0.2.x"
+    "@oriva/sdk": "0.1.x || 0.2.x || 0.3.x"
   },
   "peerDependenciesMeta": {
     "@oriva/sdk": {


### PR DESCRIPTION
## User Story

**As a** Vercel CI build,
**I want to** resolve workspace peer dependencies without conflict,
**So I can** deploy api.oriva.io successfully.

## Standards

- Peer-dep widening is patch-level (non-breaking)
- npm install must succeed without --force / --legacy-peer-deps

## User Criteria

- [x] @oriva/cli peerDependencies['@oriva/sdk'] widened from "0.1.x || 0.2.x" to "0.1.x || 0.2.x || 0.3.x"
- [x] @oriva/cli version bumped 0.2.1 → 0.2.2 (patch)

## Tech Criteria

- [x] No code changes — package.json only

## Sketch Ideas

Vercel deploys after PR #41 + #42 failed with:
```
Conflicting peer dependency: @oriva/sdk@0.2.0
peerOptional @oriva/sdk@"0.1.x || 0.2.x" from @oriva/cli@0.2.1
```

The CLI's peer range never got bumped when SDK went to 0.3.0 in PR #41. Closes that gap.

## Skills to consult

- (none — mechanical fix)

## Enhance existing approach

- [x] Prefer extending existing code/patterns over creating new abstractions

**Co-Authored-By:** Claude Opus 4.7 (1M context) <noreply@anthropic.com>