### PR TITLE
chore(ci): restore the Symphony workflows as .disabled — keep the work, not the behaviour

### DIFF
--- a/.github/ISSUE_TEMPLATE/symphony-task.md.disabled
+++ b/.github/ISSUE_TEMPLATE/symphony-task.md.disabled
@@ -1,0 +1,20 @@
+---
+name: Symphony Task
+about: Assign work to the autonomous agent queue
+title: "fix/feat: "
+labels: "symphony/todo"
+---
+
+## What
+
+<!-- One sentence: what should change and where -->
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+
+## Notes
+
+<!-- Optional: edge cases, files to avoid, deploy steps needed -->
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,31 @@
+# `.github/workflows/` — the `*.disabled` files are Symphony, deliberately switched off
+
+Any file here ending `.disabled` is **preserved, not dead**. GitHub only reads `.yml` / `.yaml` in this directory, so a `.yml.disabled` file cannot trigger, cannot produce a check, and costs no compute — while the work that went into writing it stays in front of you instead of in a commit hunt.
+
+## Why they are off
+
+Chairman, 2026-07-30: *"symphony should not be auto promoting, we are not currently using symphony"* — and then, on keeping them: *"don't delete the hard work we did to create them, just disable them so we can re-explore it in future."*
+
+They were first deleted outright (`timebinder/operations`#65), which went further than intended, then restored here as disabled files (`timebinder/operations`#67). **Symphony is not in use.** Nothing auto-claims an issue, auto-promotes a PR, moves a card, or closes a ticket on merge; a `symphony/*` label on an old ticket is historical residue.
+
+## 🔴 Do NOT just rename them back — they were already broken in two ways
+
+Both predate the deletion, so re-enabling as-is would restore something that did not work correctly:
+
+1. **They point at a dead board.** `symphony-add-to-project.yml` and `symphony-label-to-status.yml` target `users/timebinder/projects/4` (`PVT_kwHOAIHtkM4BW6tN`) — the **retired** Symphony Queue, never a live brand board. A revival must retarget them at the live board (Oriva #5 / Originals #6 / Ultra #7 / Boutique #8) and re-map the Status option IDs, which differ per board.
+2. **On the `timebinder` account, Actions cannot run at all** — it is billing-blocked; jobs return `steps: []` with *"The job was not started because recent account payments have failed"*. `0riva` and `Limohawk-Technologies` are **not** blocked and their Actions do execute. So the same file behaves differently depending on which repo it sits in.
+
+⚠️ `conclusion: failure` alone does not prove a billing block — check whether steps ran (`steps: []` = runner never started; executed steps = a real failure).
+
+## Re-enabling, when that is a deliberate decision
+
+```bash
+# 1. bring one back
+git mv .github/workflows/symphony-merge-promote.yml.disabled \
+       .github/workflows/symphony-merge-promote.yml
+
+# 2. BEFORE committing: retarget the board + Status option IDs (see point 1 above)
+# 3. confirm this repo's account can run Actions at all (see point 2 above)
+```
+
+Full context, the daemon/PM2 setup, and the per-repo restore commits: the `symphony` skill (`~/.claude/skills/symphony/SKILL.md`).

--- a/.github/workflows/symphony-add-to-project.yml.disabled
+++ b/.github/workflows/symphony-add-to-project.yml.disabled
@@ -1,0 +1,19 @@
+name: Symphony — auto-add labelled issues to project board
+
+on:
+  issues:
+    types: [opened, labeled, reopened]
+
+jobs:
+  add-to-project:
+    name: Add to Symphony Queue
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'symphony/todo') ||
+      contains(github.event.issue.labels.*.name, 'symphony/in-progress') ||
+      contains(github.event.issue.labels.*.name, 'symphony/human-review') ||
+      contains(github.event.issue.labels.*.name, 'symphony/rework')
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/timebinder/projects/4
+          github-token: ${{ secrets.SYMPHONY_PROJECT_PAT }}

--- a/.github/workflows/symphony-auto-assign-bot.yml.disabled
+++ b/.github/workflows/symphony-auto-assign-bot.yml.disabled
@@ -1,0 +1,50 @@
+name: Symphony — auto-assign ivagent when daemon claims issue
+
+# When the daemon flips an issue to symphony/in-progress, self-assign
+# the ivagent bot account so the issue's Assignee field reflects who
+# is working it. This enables "click Assign yourself" takeover semantics.
+#
+# Bot username: ivagent
+# NOTE: if the ivagent GitHub account is renamed, update the single
+# constant below. The account may not exist yet (see operations#23).
+# If it doesn't exist, gh's --add-assignee will fail gracefully; the
+# workflow is ready and will activate once the account is created.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-assign-bot:
+    name: Assign ivagent on daemon claim
+    runs-on: ubuntu-latest
+    # Guard: only fire when the label that was just added is symphony/in-progress
+    if: github.event.label.name == 'symphony/in-progress'
+    steps:
+      - name: Assign ivagent if no assignee yet
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Bot username constant — update here if account is renamed
+            const BOT_USER = 'ivagent';
+
+            const issue = context.payload.issue;
+
+            // Guard: if the issue already has any assignee, do not override.
+            // This protects human takeover: if Chairman assigned themselves
+            // before the label change arrived, we leave it alone.
+            if (issue.assignees && issue.assignees.length > 0) {
+              core.info(`Issue #${issue.number} already has assignee(s) — skipping bot self-assign.`);
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [BOT_USER],
+            });
+            core.info(`Assigned ${BOT_USER} to issue #${issue.number}.`);

--- a/.github/workflows/symphony-human-assignee-handoff.yml.disabled
+++ b/.github/workflows/symphony-human-assignee-handoff.yml.disabled
@@ -1,0 +1,89 @@
+name: Symphony — hand off to human when Chairman assigns themselves
+
+# When any non-bot user becomes the assignee on an issue, strip all
+# symphony/* labels so the daemon stops processing. This is the
+# "click Assign yourself" takeover flow.
+#
+# To hand back: human unassigns themselves → daemon picks it up on
+# next label cycle (human re-adds symphony/todo label to re-queue).
+#
+# Loop safety: Workflow A (auto-assign-bot) fires on `labeled`, not
+# `assigned`. Workflow B (this file) fires on `assigned`. Workflow A's
+# bot self-assign triggers this workflow, but guard #1 below catches
+# ivagent and exits — no loop.
+#
+# Bot username: ivagent
+# NOTE: update the BOT_USER constant if the account is renamed.
+
+on:
+  issues:
+    types: [assigned]
+
+permissions:
+  issues: write
+
+jobs:
+  human-handoff:
+    name: Strip symphony labels on human assignment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hand off if a human (non-bot) was assigned
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Bot username constant — update here if account is renamed
+            const BOT_USER = 'ivagent';
+
+            const assignee = context.payload.assignee?.login;
+            const issue = context.payload.issue;
+
+            // Guard 1: if the newly assigned user is the bot, this is the
+            // auto-assign-bot workflow firing — ignore to prevent loop.
+            if (assignee === BOT_USER) {
+              core.info(`Assignee is ${BOT_USER} (bot self-assign) — skipping handoff.`);
+              return;
+            }
+
+            // Guard 2: check whether the issue has any symphony/* labels.
+            // If not, there's nothing to strip — already handed off or never claimed.
+            const symphonyLabels = (issue.labels || [])
+              .map(l => (typeof l === 'string' ? l : l.name))
+              .filter(n => n?.startsWith('symphony/'));
+
+            if (symphonyLabels.length === 0) {
+              core.info(`Issue #${issue.number} has no symphony/* labels — nothing to strip.`);
+              return;
+            }
+
+            core.info(`Human ${assignee} assigned to #${issue.number}. Stripping labels: ${symphonyLabels.join(', ')}`);
+
+            // Remove all symphony/* state labels
+            for (const label of symphonyLabels) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: label,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            // Remove ivagent as assignee if present (clean handoff — only
+            // the human is assigned going forward)
+            const botIsAssigned = (issue.assignees || [])
+              .some(a => a.login === BOT_USER);
+
+            if (botIsAssigned) {
+              await github.rest.issues.removeAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [BOT_USER],
+              });
+              core.info(`Removed ${BOT_USER} as assignee from #${issue.number}.`);
+            }
+
+            core.info(`Handoff complete. Issue #${issue.number} is now owned by ${assignee}.`);

--- a/.github/workflows/symphony-label-to-status.yml.disabled
+++ b/.github/workflows/symphony-label-to-status.yml.disabled
@@ -1,0 +1,181 @@
+name: Symphony — label change → project Status column
+
+# Fires when a label is added or removed on any issue in this repo.
+# If the changed label is a symphony/* state label, finds the issue's project
+# item on IV Project board #4 (timebinder) and updates the Status field to match.
+#
+# This is the INVERSE of symphony-status-to-label.yml (which polls Status → labels).
+# Together they form a bidirectional sync. Idempotence guards prevent an infinite loop:
+#   - This workflow reads current Status before writing; no-ops if already correct.
+#   - The polling workflow skips if labels already match Status.
+# Loop scenario: human drags card → polling sets label → this workflow fires →
+#   reads Status, finds match → no-op. Dead after one cycle.
+#
+# Required secret: SYMPHONY_PROJECT_PAT
+#   Classic PAT (timebinder account) with scopes: repo, project
+#
+# Label → Status option ID mapping (project PVT_kwHOAIHtkM4BW6tN):
+#   symphony/todo          → 24710543
+#   symphony/in-progress   → effa981c
+#   symphony/human-review  → d8493e20
+#   symphony/rework        → 0cd033e4
+#   symphony/done          → f31dd533
+#
+# Precedence (multiple symphony/* labels): in-progress > rework > human-review > todo > done
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  issues: read
+  contents: read
+
+jobs:
+  sync-label-to-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync symphony/* label → project Status field
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SYMPHONY_PROJECT_PAT }}
+          script: |
+            // ── Config ─────────────────────────────────────────────────────────
+            const PROJECT_OWNER  = 'timebinder';
+            const PROJECT_NUMBER = 4;
+            const PROJECT_ID     = 'PVT_kwHOAIHtkM4BW6tN';
+            const STATUS_FIELD_ID = 'PVTSSF_lAHOAIHtkM4BW6tNzhSLP60';
+
+            // symphony/* label → Status option ID
+            const LABEL_TO_OPTION = {
+              'symphony/todo':         '24710543',
+              'symphony/in-progress':  'effa981c',
+              'symphony/human-review': 'd8493e20',
+              'symphony/rework':       '0cd033e4',
+              'symphony/done':         'f31dd533',
+            };
+
+            // Precedence order (highest first) for multi-label resolution
+            const PRECEDENCE = [
+              'symphony/in-progress',
+              'symphony/rework',
+              'symphony/human-review',
+              'symphony/todo',
+              'symphony/done',
+            ];
+
+            const ALL_SYMPHONY_LABELS = new Set(Object.keys(LABEL_TO_OPTION));
+
+            // ── Guard: only act on symphony/* label events ────────────────────
+            const changedLabel = context.payload.label?.name ?? '';
+            if (!ALL_SYMPHONY_LABELS.has(changedLabel)) {
+              core.info(`Label "${changedLabel}" is not a symphony/* label — no-op`);
+              return;
+            }
+
+            const issueNumber   = context.payload.issue.number;
+            const issueNodeId   = context.payload.issue.node_id;
+            const repoOwner     = context.repo.owner;
+            const repoName      = context.repo.repo;
+
+            core.info(`symphony/* label event on #${issueNumber}: "${changedLabel}" ${context.payload.action}`);
+
+            // ── Determine which symphony/* labels are currently on the issue ──
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner:        repoOwner,
+              repo:         repoName,
+              issue_number: issueNumber,
+            });
+
+            const presentSymphonyLabels = currentLabels
+              .map(l => l.name)
+              .filter(n => ALL_SYMPHONY_LABELS.has(n));
+
+            // Resolve target label by precedence
+            let targetLabel = null;
+            for (const label of PRECEDENCE) {
+              if (presentSymphonyLabels.includes(label)) {
+                targetLabel = label;
+                break;
+              }
+            }
+
+            if (!targetLabel) {
+              core.info(`No symphony/* labels remain on #${issueNumber} — no Status update`);
+              return;
+            }
+
+            const targetOptionId = LABEL_TO_OPTION[targetLabel];
+            core.info(`Target Status for #${issueNumber}: "${targetLabel}" → optionId ${targetOptionId}`);
+
+            // ── Find the project item ID for this issue ────────────────────────
+            const itemData = await github.graphql(`
+              query($issueId: ID!) {
+                node(id: $issueId) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project {
+                          id
+                          number
+                          owner {
+                            ... on User { login }
+                          }
+                        }
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            optionId
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { issueId: issueNodeId });
+
+            const projectItems = itemData?.node?.projectItems?.nodes ?? [];
+
+            // Filter to IV Project board #4 owned by timebinder
+            const boardItem = projectItems.find(item =>
+              item?.project?.number === PROJECT_NUMBER &&
+              item?.project?.owner?.login === PROJECT_OWNER
+            );
+
+            if (!boardItem) {
+              core.info(`Issue #${issueNumber} is not on project board ${PROJECT_NUMBER} — no-op`);
+              return;
+            }
+
+            const projectItemId     = boardItem.id;
+            const currentOptionId   = boardItem?.fieldValueByName?.optionId ?? null;
+
+            // ── Idempotence guard: skip if Status already matches ─────────────
+            if (currentOptionId === targetOptionId) {
+              core.info(`Status already correct (${targetOptionId}) for #${issueNumber} — no-op (loop guard)`);
+              return;
+            }
+
+            core.info(`Updating Status for #${issueNumber}: ${currentOptionId ?? '(unset)'} → ${targetOptionId}`);
+
+            // ── Update the Status field on the project item ───────────────────
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId:    $itemId
+                  fieldId:   $fieldId
+                  value:     { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `, {
+              projectId: PROJECT_ID,
+              itemId:    projectItemId,
+              fieldId:   STATUS_FIELD_ID,
+              optionId:  targetOptionId,
+            });
+
+            core.info(`Done — #${issueNumber} Status updated to "${targetLabel}"`);

--- a/.github/workflows/symphony-merge-promote.yml.disabled
+++ b/.github/workflows/symphony-merge-promote.yml.disabled
@@ -1,0 +1,96 @@
+name: Symphony — auto-promote merged PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  promote:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find linked Symphony issue and promote
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = (pr.body || '') + '\n' + (pr.title || '');
+
+            // Match "Closes #N", "Fixes #N", "Resolves #N" (case-insensitive)
+            const re = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+            let m;
+            while ((m = re.exec(body)) !== null) issueNumbers.add(parseInt(m[1], 10));
+
+            // Also branches named symphony/issue-<N>
+            const branchMatch = (pr.head?.ref || '').match(/symphony\/issue-(\d+)/);
+            if (branchMatch) issueNumbers.add(parseInt(branchMatch[1], 10));
+
+            if (issueNumbers.size === 0) {
+              core.info('No linked Symphony issue found — skipping.');
+              return;
+            }
+
+            for (const num of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                const isSymphony = issue.labels.some(
+                  l => (typeof l === 'string' ? l : l.name)?.startsWith('symphony/')
+                );
+                if (!isSymphony) {
+                  core.info(`Issue #${num} is not a Symphony issue — skipping.`);
+                  continue;
+                }
+
+                // Swap labels: human-review/in-progress → done
+                const stripLabels = ['symphony/human-review', 'symphony/in-progress', 'symphony/rework', 'symphony/todo'];
+                for (const label of stripLabels) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: num,
+                      name: label,
+                    });
+                  } catch (e) {
+                    if (e.status !== 404) throw e;
+                  }
+                }
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  labels: ['symphony/done'],
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  body: `Auto-closed by symphony-merge-promote — PR #${pr.number} merged into \`${pr.base.ref}\`.`,
+                });
+
+                if (issue.state === 'open') {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    state: 'closed',
+                    state_reason: 'completed',
+                  });
+                }
+
+                core.info(`Promoted issue #${num} to done.`);
+              } catch (e) {
+                core.warning(`Failed to promote issue #${num}: ${e.message}`);
+              }
+            }

--- a/.github/workflows/symphony-status-to-label.yml.disabled
+++ b/.github/workflows/symphony-status-to-label.yml.disabled
@@ -1,0 +1,170 @@
+name: Symphony — poll Status column → labels
+
+# Polls the IV Project board (user-owned, https://github.com/users/timebinder/projects/4)
+# every 2 minutes and syncs each issue's Status field → matching symphony/* label.
+#
+# Why polling (not webhooks): projects_v2_item webhook events are organisation-level only.
+# The IV Project board is user-owned, so webhooks never fire. This workflow polls via
+# GraphQL instead. Each repo installs an identical copy; each copy only processes issues
+# in its own repository to avoid cross-repo label writes.
+#
+# Required secret: SYMPHONY_PROJECT_PAT
+#   Classic PAT (timebinder account) with scopes: repo, read:project
+#   Must be set on every repo that installs this workflow.
+#
+# Status → label mapping:
+#   Todo          → symphony/todo
+#   In Progress   → symphony/in-progress
+#   Human Review  → symphony/human-review
+#   Rework        → symphony/rework
+#   Done          → symphony/done
+
+on:
+  workflow_dispatch: # allow manual runs for testing
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  poll-and-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync project Status → symphony/* labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SYMPHONY_PROJECT_PAT }}
+          script: |
+            // ── Config ─────────────────────────────────────────────────────────
+            const PROJECT_OWNER   = 'timebinder';
+            const PROJECT_NUMBER  = 4;
+            const THIS_REPO_OWNER = context.repo.owner;
+            const THIS_REPO_NAME  = context.repo.repo;
+
+            // Status option ID → symphony/* label
+            const STATUS_MAP = {
+              '24710543': 'symphony/todo',
+              'effa981c': 'symphony/in-progress',
+              'd8493e20': 'symphony/human-review',
+              '0cd033e4': 'symphony/rework',
+              'f31dd533': 'symphony/done',
+            };
+
+            const ALL_SYMPHONY_LABELS = new Set(Object.values(STATUS_MAP));
+
+            // ── Fetch all items from the project board ─────────────────────────
+            // Fetch up to 100 items (more than enough for current board size).
+            // If the board ever exceeds 100, add pagination here.
+            const projectData = await github.graphql(`
+              query($owner: String!, $number: Int!) {
+                user(login: $owner) {
+                  projectV2(number: $number) {
+                    items(first: 100) {
+                      totalCount
+                      nodes {
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            optionId
+                          }
+                        }
+                        content {
+                          ... on Issue {
+                            number
+                            repository {
+                              name
+                              owner { login }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { owner: PROJECT_OWNER, number: PROJECT_NUMBER });
+
+            const allItems = projectData?.user?.projectV2?.items?.nodes ?? [];
+
+            // ── Filter to issues in THIS repo only ─────────────────────────────
+            const myItems = allItems.filter(item => {
+              const content = item?.content;
+              return (
+                content?.number &&
+                content?.repository?.owner?.login === THIS_REPO_OWNER &&
+                content?.repository?.name === THIS_REPO_NAME
+              );
+            });
+
+            let changesCount = 0;
+
+            // ── Reconcile labels for each issue ────────────────────────────────
+            for (const item of myItems) {
+              const issueNum  = item.content.number;
+              const optionId  = item?.fieldValueByName?.optionId;
+              const wantLabel = optionId ? STATUS_MAP[optionId] : null;
+
+              // Fetch current labels on the issue
+              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner:        THIS_REPO_OWNER,
+                repo:         THIS_REPO_NAME,
+                issue_number: issueNum,
+              });
+
+              const currentSymphonyLabels = currentLabels
+                .map(l => l.name)
+                .filter(n => ALL_SYMPHONY_LABELS.has(n));
+
+              // Idempotence check: if already correct, skip silently
+              if (
+                wantLabel &&
+                currentSymphonyLabels.length === 1 &&
+                currentSymphonyLabels[0] === wantLabel
+              ) {
+                continue;
+              }
+
+              // Strip stale symphony/* labels
+              for (const stale of currentSymphonyLabels) {
+                if (stale !== wantLabel) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner:        THIS_REPO_OWNER,
+                      repo:         THIS_REPO_NAME,
+                      issue_number: issueNum,
+                      name:         stale,
+                    });
+                  } catch (e) {
+                    if (e.status !== 404) throw e;
+                  }
+                }
+              }
+
+              // Apply the correct label (if Status is set)
+              if (wantLabel) {
+                await github.rest.issues.addLabels({
+                  owner:        THIS_REPO_OWNER,
+                  repo:         THIS_REPO_NAME,
+                  issue_number: issueNum,
+                  labels:       [wantLabel],
+                });
+
+                const was = currentSymphonyLabels.length
+                  ? currentSymphonyLabels.join(', ')
+                  : '(none)';
+                core.info(`#${issueNum}: set ${wantLabel} (was: ${was})`);
+                changesCount++;
+              } else {
+                // Status is unset on the board — strip all symphony/* labels
+                if (currentSymphonyLabels.length > 0) {
+                  core.info(`#${issueNum}: Status unset on board — stripped ${currentSymphonyLabels.join(', ')}`);
+                  changesCount++;
+                }
+              }
+            }
+
+            // ── Summary (only printed once per run) ───────────────────────────
+            if (changesCount === 0) {
+              core.info(`No changes — ${myItems.length} item(s) checked in ${THIS_REPO_OWNER}/${THIS_REPO_NAME}`);
+            } else {
+              core.info(`Done — ${changesCount} change(s) across ${myItems.length} item(s) in ${THIS_REPO_OWNER}/${THIS_REPO_NAME}`);
+            }


### PR DESCRIPTION
## Summary

- Restores the Symphony workflows and issue template **byte-for-byte** from the pre-deletion commit, renamed to `.disabled`. Part of `timebinder/operations`#67 — https://github.com/timebinder/operations/issues/67.
- Chairman: *"don't delete the hard work we did to create them, just disable them so we can re-explore it in future."* The earlier sweep deleted them outright, which went further than the instruction — the ask was that we are not **currently** using Symphony, not that it is gone for good.
- Adds `.github/workflows/README.md` so a future session finds them without knowing this ticket exists, and — more importantly — does **not** simply rename one back.

**Disabled by extension, not `if: false`.** GitHub reads only `.yml`/`.yaml` in `.github/workflows/`, so a renamed file cannot trigger: no run, no check, no compute. `if: false` would be the wrong tool — the workflow still fires, still appears in the checks list, and still consumes a run, reintroducing the permanent-red problem the sweep removed. Same reasoning for `symphony-task.md.disabled`: it stays out of the new-issue picker.

## 🔴 Two things that were already broken before the deletion

Recorded in the README so a revival does not start from a false sense of readiness:

1. **They target a dead board.** `symphony-add-to-project.yml` and `symphony-label-to-status.yml` point at `users/timebinder/projects/4` (`PVT_kwHOAIHtkM4BW6tN`) — the **retired** Symphony Queue, never a live brand board. A revival must retarget them and re-map Status option IDs, which differ per board.
2. **Actions availability is per-account.** `timebinder` is billing-blocked (jobs return `steps: []` with *"The job was not started because recent account payments have failed"*); `0riva` and `Limohawk-Technologies` are **not**. The same file behaves differently depending on which repo it sits in.

## Verification

CI config + docs only. **No source file touched.**

- **Restored from the recorded parent commit**, not hand-rewritten — the whole point is preserving the original work intact.
- **Zero live Symphony workflows** — `ls .github/workflows/*.yml | grep -c symphony` → `0`. Every restored file carries the `.disabled` suffix.
- **Inertness is structural, not configured** — GitHub's workflow loader ignores non-`.yml`/`.yaml` files in that directory, so there is no trigger path at all.
- **Post-merge check** (the one that actually proves it): confirm the merge commit shows **zero workflow runs and zero check-runs**. This matters most on `0riva` repos, where Actions genuinely execute — an inertness claim there is not satisfied by "the runner is blocked anyway".

- [x] Local tests pass — n/a, no source changed
- [x] Cross-system claims in PR body have cite-able evidence — restore commit recorded in the `symphony` skill; billing annotation quoted verbatim
- [ ] Live URL / user-visible behaviour verified — n/a, no user-visible surface; the observable effect is that GitHub lists no Symphony workflow

## Test plan

- [x] Confirm no `.yml` Symphony file remains (only `.yml.disabled`)
- [x] Confirm the restored content is the original, not a rewrite
- [x] Confirm the issue template is `.md.disabled` so it cannot appear in the picker
- [ ] After merge: confirm zero workflow runs / check-runs on the merge commit
- [ ] After merge: confirm the new-issue picker offers no "Symphony Task"
