### PR TITLE
fix(limohawk): make the booking webhook actually award and claw back points

### DIFF
--- a/api/cron/limohawk.ts
+++ b/api/cron/limohawk.ts
@@ -13,7 +13,7 @@
  */
 
 import { VercelRequest, VercelResponse } from '@vercel/node';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
 import {
   sendExpiryWarningEmail,
   wasNotificationSent,
@@ -30,10 +30,11 @@ const CRON_SECRET = process.env.LIMOHAWK_CRON_SECRET;
 // Supabase Client
 // ============================================================================
 
-function getSupabaseServiceClient(): SupabaseClient {
+function getSupabaseServiceClient() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { db: { schema: 'limohawk' } }
   );
 }
 
@@ -133,7 +134,7 @@ async function runExpirePointsJob(): Promise<JobResult> {
 
   try {
     // Call the stored function
-    const { data, error } = await supabase.rpc('limohawk.expire_inactive_points');
+    const { data, error } = await supabase.rpc('expire_inactive_points');
 
     if (error) {
       console.error('[LimohawkCron] expire_inactive_points error:', error);
@@ -203,7 +204,7 @@ async function runExpiryWarningsJob(): Promise<JobResult> {
       rangeEnd.setDate(rangeEnd.getDate() - targetDaysAgo);
 
       const { data: accounts, error } = await supabase
-        .from('limohawk.loyalty_accounts')
+        .from('loyalty_accounts')
         .select('id, email, name, points_balance, last_activity_at')
         .gte('last_activity_at', rangeStart.toISOString())
         .lt('last_activity_at', rangeEnd.toISOString())

--- a/src/handlers/webhooks/limohawk.ts
+++ b/src/handlers/webhooks/limohawk.ts
@@ -16,7 +16,7 @@
 
 import crypto from 'crypto';
 import { Request, Response } from 'express';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
 
 // ============================================================================
 // Types
@@ -58,12 +58,20 @@ const LIMOHAWK_WEBHOOK_SECRET = process.env.LIMOHAWK_WEBHOOK_SECRET || '';
 // Supabase Client
 // ============================================================================
 
-function getSupabaseServiceClient(): SupabaseClient {
+function getSupabaseServiceClient() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { db: { schema: 'limohawk' } }
   );
 }
+
+/**
+ * A client bound to the `limohawk` schema. Inferred rather than annotated as
+ * `SupabaseClient`, whose default type parameters pin the schema to `public` and
+ * would reject this client.
+ */
+type LimohawkClient = ReturnType<typeof getSupabaseServiceClient>;
 
 // ============================================================================
 // HMAC Signature Verification
@@ -104,13 +112,13 @@ function verifySignature(payload: string, signature: string, secret: string): bo
  * Returns the event ID if successfully stored, null if duplicate
  */
 async function storeBookingEvent(
-  supabase: SupabaseClient,
+  supabase: LimohawkClient,
   payload: LimohawkWebhookPayload,
   rawPayload: string
 ): Promise<string | null> {
   try {
     const { data, error } = await supabase
-      .from('limohawk.booking_events')
+      .from('booking_events')
       .insert({
         booking_id: payload.booking_id,
         external_customer_id: payload.customer.id,
@@ -145,12 +153,12 @@ async function storeBookingEvent(
  * Mark event as processed
  */
 async function markEventProcessed(
-  supabase: SupabaseClient,
+  supabase: LimohawkClient,
   eventId: string,
   error?: string
 ): Promise<void> {
   await supabase
-    .from('limohawk.booking_events')
+    .from('booking_events')
     .update({
       processed_at: new Date().toISOString(),
       processing_error: error || null,
@@ -166,13 +174,13 @@ async function markEventProcessed(
  * Handle booking.completed event - Award loyalty points
  */
 async function handleBookingCompleted(
-  supabase: SupabaseClient,
+  supabase: LimohawkClient,
   payload: LimohawkWebhookPayload
 ): Promise<AwardPointsResult> {
   const { customer, booking_id, fare } = payload;
 
   // Call the stored function to award points
-  const { data, error } = await supabase.rpc('limohawk.award_points', {
+  const { data, error } = await supabase.rpc('award_points', {
     p_external_customer_id: customer.id,
     p_email: customer.email,
     p_name: customer.name || null,
@@ -199,14 +207,14 @@ async function handleBookingCompleted(
  * Handle booking.refunded event - Process refund
  */
 async function handleBookingRefunded(
-  supabase: SupabaseClient,
+  supabase: LimohawkClient,
   payload: LimohawkWebhookPayload
 ): Promise<void> {
   const { customer, booking_id } = payload;
 
   // Find the original points awarded for this booking
   const { data: originalTransaction } = await supabase
-    .from('limohawk.points_ledger')
+    .from('points_ledger')
     .select('account_id, points_amount')
     .eq('booking_id', booking_id)
     .eq('transaction_type', 'booking_earn')
@@ -218,7 +226,7 @@ async function handleBookingRefunded(
   }
 
   // Deduct the points (negative adjustment)
-  const { error } = await supabase.rpc('limohawk.admin_adjust_points', {
+  const { error } = await supabase.rpc('admin_adjust_points', {
     p_account_id: originalTransaction.account_id,
     p_points_adjustment: -originalTransaction.points_amount,
     p_reason: `Refund for booking ${booking_id}`,

--- a/tests/contract/limohawk-schema-qualification.test.ts
+++ b/tests/contract/limohawk-schema-qualification.test.ts
@@ -1,0 +1,201 @@
+/**
+ * LimoHawk PostgREST schema-qualification contract.
+ *
+ * The `limohawk` tables and functions live in their own Postgres schema. PostgREST
+ * selects a schema with a HEADER (`Accept-Profile` on reads, `Content-Profile` on
+ * writes/RPC) — it never parses a dot in the URL path as a schema separator. So
+ * `.rpc('limohawk.award_points')` posts to /rest/v1/rpc/limohawk.award_points, which
+ * PostgREST resolves as `public.limohawk.award_points` and 404s with PGRST202. Every
+ * booking webhook therefore awarded zero points, and every refund deducted none.
+ *
+ * The working form is to build the client with `{ db: { schema: 'limohawk' } }` and
+ * reference tables and functions unqualified.
+ *
+ * These tests assert the RESOLVED REQUEST that supabase-js emits. A mock of
+ * `supabase.rpc` would pass against either form and prove nothing, so we stub
+ * `globalThis.fetch` and let the real client build the URL and headers.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const SUPABASE_URL = 'https://test-project.supabase.co';
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+interface CapturedRequest {
+  path: string;
+  headers: Record<string, string>;
+}
+
+let captured: CapturedRequest[] = [];
+let realFetch: typeof globalThis.fetch;
+
+type FetchArgs = Parameters<typeof globalThis.fetch>;
+type FetchInput = FetchArgs[0];
+type FetchInit = FetchArgs[1];
+
+function normaliseHeaders(init?: FetchInit): Record<string, string> {
+  const raw = init?.headers;
+  if (!raw) return {};
+  const entries =
+    raw instanceof Headers
+      ? Array.from(raw.entries())
+      : Array.isArray(raw)
+        ? raw
+        : Object.entries(raw as Record<string, string>);
+  return Object.fromEntries(entries.map(([k, v]) => [String(k).toLowerCase(), String(v)]));
+}
+
+function mockRes() {
+  const state: { code?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      state.code = code;
+      return res;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return res;
+    },
+    state,
+  };
+  return res;
+}
+
+const schemaHeader = (r: CapturedRequest) =>
+  r.headers['accept-profile'] ?? r.headers['content-profile'];
+
+describe('LimoHawk PostgREST schema qualification', () => {
+  beforeEach(() => {
+    captured = [];
+    realFetch = globalThis.fetch;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+    process.env.LIMOHAWK_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+    globalThis.fetch = (async (input: FetchInput, init?: FetchInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : String((input as { url: string }).url);
+      if (!url.startsWith(SUPABASE_URL)) {
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      const headers = normaliseHeaders(init);
+      captured.push({ path: new URL(url).pathname, headers });
+
+      // Honour PostgREST's single-object representation so the handler's
+      // `.single()` reads resolve and the flow continues to the RPC calls.
+      const wantsObject = (headers['accept'] ?? '').includes('pgrst.object');
+      const row = { id: 'evt-1', account_id: 'acct-1', points_amount: 25 };
+      return new Response(JSON.stringify(wantsObject ? row : [row]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  async function postWebhook(eventType: string) {
+    // The handler reads LIMOHAWK_WEBHOOK_SECRET at module load, so require it
+    // after the env var is set.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { handleLimohawkWebhook } = require('../../src/handlers/webhooks/limohawk');
+
+    const payload = {
+      event_type: eventType,
+      booking_id: 'bk-1',
+      customer: { id: 'cust-1', email: 't***@example.com', name: 'Test' },
+      fare: { gross_pence: 30_000, vat_pence: 5_000, net_pence: 25_000 },
+      timestamp: '2026-08-03T00:00:00.000Z',
+    };
+    const rawBody = JSON.stringify(payload);
+    const signature = crypto
+      .createHmac('sha256', WEBHOOK_SECRET)
+      .update(rawBody, 'utf8')
+      .digest('hex');
+
+    const req = {
+      method: 'POST',
+      headers: { 'x-limohawk-signature': signature },
+      body: payload,
+    };
+    const res = mockRes();
+    await handleLimohawkWebhook(req as never, res as never);
+    return res;
+  }
+
+  it('a completed booking awards points via a bare function name in the limohawk schema', async () => {
+    await postWebhook('booking.completed');
+
+    expect(captured.length).toBeGreaterThan(0);
+    const paths = captured.map((r) => r.path);
+    // The dotted form emitted /rest/v1/rpc/limohawk.award_points -> PGRST202.
+    expect(paths).toContain('/rest/v1/rpc/award_points');
+    expect(paths).toContain('/rest/v1/booking_events');
+  });
+
+  it('a refund deducts points via a bare function name in the limohawk schema', async () => {
+    await postWebhook('booking.refunded');
+
+    const paths = captured.map((r) => r.path);
+    expect(paths).toContain('/rest/v1/points_ledger');
+    expect(paths).toContain('/rest/v1/rpc/admin_adjust_points');
+  });
+
+  it('never emits a dotted relation, and every request selects the limohawk schema by header', async () => {
+    await postWebhook('booking.completed');
+
+    expect(captured.length).toBeGreaterThan(0);
+    for (const req of captured) {
+      const relation = req.path.replace(/^\/rest\/v1\/(rpc\/)?/, '');
+      expect(relation).not.toContain('.');
+      expect(schemaHeader(req)).toBe('limohawk');
+    }
+  });
+});
+
+describe('LimoHawk source guard: no schema-qualified relation literals', () => {
+  // Scoped to the `limohawk` schema. Other schemas in this repo (whiteboard_canvas,
+  // video_meetings, merlin_ai) carry the same defect and are tracked separately.
+  const roots = [path.resolve(__dirname, '../../src'), path.resolve(__dirname, '../../api')];
+
+  function walk(dir: string): string[] {
+    let out: string[] = [];
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return out;
+    }
+    for (const entry of entries) {
+      if (entry === 'node_modules') continue;
+      const full = path.join(dir, entry);
+      if (fs.statSync(full).isDirectory()) out = out.concat(walk(full));
+      else if (/\.tsx?$/.test(full)) out.push(full);
+    }
+    return out;
+  }
+
+  const files = roots.flatMap(walk);
+
+  it('finds source files to scan (guards against a vacuous pass)', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it('no .from() or .rpc() call names a limohawk-qualified relation', () => {
+    const dotted = /\.(from|rpc)\(\s*['"`]limohawk\.([A-Za-z_][A-Za-z0-9_]*)['"`]/g;
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const source = fs.readFileSync(file, 'utf8');
+      for (const match of source.matchAll(dotted)) {
+        const line = source.slice(0, match.index).split('\n').length;
+        offenders.push(`${path.relative(process.cwd(), file)}:${line} → .${match[1]}('limohawk.${match[2]}')`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- The LimoHawk booking webhook and the expiry cron named their tables and functions in **dotted schema-qualified form** (`.rpc('limohawk.award_points')`, `.from('limohawk.points_ledger')`). PostgREST does not read a dot as a schema separator — it prefixes the request's schema to the whole string, so these resolved as `public.limohawk.award_points` and failed.
- **Consequence: a completed booking awarded nothing, and a refund clawed nothing back.** `limohawk.points_ledger` holds zero rows.
- Fixed by building the client with `{ db: { schema: 'limohawk' } }` and referencing relations unqualified. Companion to timebinder/o-sites#32, which fixes the same defect on the o-sites side; that repo owns the customer-facing loyalty surface, this one owns the booking webhook that feeds it.
- Scope note: the originating ticket listed one call site in this repo (`handlers/webhooks/limohawk.ts:221`). The real count is **7 across 2 files** — it missed `award_points` in the same file and `api/cron/limohawk.ts` entirely.

## Verification

**Live read-only probes against production, run before any change.** Project ref `cbzgvlkizkdfjmbrosav` (shared OrivaDB). Actual responses:

```
[dotted-rpc]     POST /rest/v1/rpc/limohawk.get_account_summary
                 HTTP=404 "code":"PGRST202"
                 details: "Searched for the function public.limohawk.get_account_summary"

[profile-rpc]    POST /rest/v1/rpc/get_account_summary   (-H "Content-Profile: limohawk")
                 HTTP=200  body=[]

[dotted-from]    GET  /rest/v1/limohawk.loyalty_accounts
                 HTTP=404 "code":"PGRST205"
                 "message":"Could not find the table 'public.limohawk.loyalty_accounts' in the schema cache"

[schema-header]  GET  /rest/v1/loyalty_accounts   (-H "Accept-Profile: limohawk")
                 HTTP=200
```

Row counts in the `limohawk` schema (`Prefer: count=exact`): `points_ledger: 0`, `booking_events: 0`, `loyalty_accounts: 0`.

**Type annotations.** `: SupabaseClient` is dropped from both factories (`src/handlers/webhooks/limohawk.ts:61`, `api/cron/limohawk.ts:33`), and the four helpers that receive a client now take `LimohawkClient` — inferred via `ReturnType<typeof getSupabaseServiceClient>`. `SupabaseClient` without type arguments pins the schema to `public`; `ts-jest` rejected the corrected client against it with:

```
error TS2322: Type 'SupabaseClient<any, any, "limohawk", any, any>' is not assignable to
              type 'SupabaseClient<any, "public", "public", any, any>'.
```

The annotation also helped mask the original defect — the type asserted a public-schema client while the code passed schema-qualified names.

**Command output:**

```
$ npx jest tests/contract/limohawk-schema-qualification.test.ts
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total

$ npx tsc --project api/tsconfig.json --noEmit
src/express/routes/payments.ts(42,7): error TS2322: Type '"2025-10-29.clover"' is not assignable to type '"2025-09-30.clover"'.
```

That single `tsc` error is **pre-existing on `main` and unrelated** to this PR: `payments.ts` is not in this diff (`git diff --name-only` confirms), and the installed `stripe` version matches the lockfile exactly (both `19.0.0`), so it is not an install artifact. Since this repo's CI lists type-check as a hard gate, it is filed separately.

**Test-environment note.** The repo's committed `package-lock.json` is out of sync with `package.json` (`npm ci` fails: `Missing: @oriva/cli@0.1.1, @oriva/sdk@0.2.0` from lock file), and the main checkout's `node_modules` was built by pnpm, producing a `jest` 30.4.2 / `jest-cli` 30.2.0 mismatch that made **every** suite fail to run with `TypeError: this._moduleMocker.clearMocksOnScope is not a function` — confirmed on an untouched pre-existing test as a control. Worked around locally with `npm install --no-save` (lockfile untouched, confirmed clean in `git status`); the control test then passed. Also filed separately.

- [x] Local tests pass — 5/5 in the new suite; a pre-existing control test also passes
- [x] Cross-system claims in PR body have cite-able evidence — probe output, `tsc` output and `file:line` citations above
- [ ] Live URL / DB row / user-visible behaviour verified — **explicitly deferred**: proving a booking awards points requires a real booking through the LimoHawk webhook. The DB-contract half is verified above; the end-to-end half is a post-merge check once this and timebinder/o-sites#32 are both deployed.

## Test plan

`tests/contract/limohawk-schema-qualification.test.ts` drives the real `handleLimohawkWebhook` with an HMAC-signed payload and stubs `globalThis.fetch`, so supabase-js builds the URL itself. It asserts the **resolved request path and schema header** — a mock of `supabase.rpc` would pass against either form and prove nothing.

- [x] **Mutation-tested**: restoring one dotted call (`rpc('award_points')` → `rpc('limohawk.award_points')`) turns **3 of 5 tests red**; reverting returns them green. The guard is not decorative.
- [x] Vacuity guard included — one test asserts the source scan actually found files, so an empty scan cannot pass silently
- [x] `booking.completed` → `/rest/v1/rpc/award_points` and `/rest/v1/booking_events`
- [x] `booking.refunded` → `/rest/v1/points_ledger` and `/rest/v1/rpc/admin_adjust_points` (the refund claw-back the ticket asks for)
- [x] No request emits a dotted relation, and every one carries `Content-Profile: limohawk`
- [x] Source guard, scoped to the `limohawk` schema, covers the whole of `src/` and `api/`
- [ ] Post-merge: a completed booking awards points visible on the customer's account, and a refund deducts them

Refs timebinder/o-sites#28
