### PR TITLE
fix(limohawk): read SUPABASE_URL — the webhook 500s on every request without it

### DIFF
--- a/src/handlers/webhooks/limohawk.ts
+++ b/src/handlers/webhooks/limohawk.ts
@@ -58,12 +58,27 @@ const LIMOHAWK_WEBHOOK_SECRET = process.env.LIMOHAWK_WEBHOOK_SECRET || '';
 // Supabase Client
 // ============================================================================
 
+/**
+ * This service's Supabase URL is `SUPABASE_URL`. `NEXT_PUBLIC_SUPABASE_URL` is
+ * the Next.js convention used by o-sites and is NOT set in this project's
+ * production environment — reading it yields `undefined`, `createClient` throws
+ * "supabaseUrl is required", and because this factory is called BEFORE the
+ * handler's try block that surfaced as an unhandled 500 on every request. The
+ * live endpoint returned 500 for both a missing and a malformed signature,
+ * where it should have returned 400 then 403.
+ *
+ * Fall back to the NEXT_PUBLIC form so local setups carrying only that name
+ * keep working.
+ */
 function getSupabaseServiceClient() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { db: { schema: 'limohawk' } }
-  );
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      'Supabase not configured: set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY',
+    );
+  }
+  return createClient(url, key, { db: { schema: 'limohawk' } });
 }
 
 /**
@@ -254,9 +269,14 @@ export async function handleLimohawkWebhook(req: Request, res: Response): Promis
     return;
   }
 
-  const supabase = getSupabaseServiceClient();
-
   try {
+    // Built INSIDE the try: a misconfiguration here should surface as a handled
+    // 500 with a logged reason, not an unhandled throw that masks every other
+    // response code. Previously this sat above the try, so a missing env var
+    // made the endpoint return 500 to a missing signature (should be 400) and
+    // to a bad signature (should be 403) — indistinguishable from a real fault.
+    const supabase = getSupabaseServiceClient();
+
     // 1. Get signature from headers
     const signature = req.headers['x-limohawk-signature'] as string;
     if (!signature) {

--- a/tests/contract/limohawk-schema-qualification.test.ts
+++ b/tests/contract/limohawk-schema-qualification.test.ts
@@ -126,6 +126,23 @@ describe('LimoHawk PostgREST schema qualification', () => {
     return res;
   }
 
+  it('resolves Supabase from SUPABASE_URL — the name this service actually has in production', async () => {
+    // o-platform production sets SUPABASE_URL, NOT NEXT_PUBLIC_SUPABASE_URL (the
+    // Next.js/o-sites convention). Reading only the NEXT_PUBLIC name yielded
+    // undefined, createClient threw "supabaseUrl is required", and because the
+    // factory sat above the handler's try block that surfaced as an unhandled
+    // 500 on EVERY request — the live endpoint returned 500 to both a missing
+    // and a malformed signature, where it owes 400 then 403.
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.SUPABASE_URL = SUPABASE_URL;
+
+    const res = await postWebhook('booking.completed');
+
+    // Reached the handler and did real work rather than throwing at construction.
+    expect(captured.length).toBeGreaterThan(0);
+    expect(res.state.code).not.toBe(500);
+  });
+
   it('a completed booking awards points via a bare function name in the limohawk schema', async () => {
     await postWebhook('booking.completed');
 


### PR DESCRIPTION
## Summary

- **The loyalty webhook has been returning 500 to every caller in production.** Not a signature problem and not the schema defect fixed in #52 — it never reached either check.
- `getSupabaseServiceClient()` read `NEXT_PUBLIC_SUPABASE_URL`, which this service does not have. Reads `SUPABASE_URL` now, and is built inside the try block so a misconfiguration is a handled error rather than an unhandled throw.

## Verification

**Observed live, before this change:**

```
$ curl -X POST https://api.oriva.io/api/webhooks/limohawk -d '{}'
HTTP=500          # owes 400 MISSING_SIGNATURE

$ curl -X POST https://api.oriva.io/api/webhooks/limohawk -H 'x-limohawk-signature: deadbeef' -d '{}'
HTTP=500          # owes 403 INVALID_SIGNATURE
```

Both paths 500 — so it was failing before the signature logic, at construction.

**The cause, verified by exact match against the deployed environment.** The Supabase names actually present in production:

```
SUPABASE_URL
SUPABASE_ANON_KEY
SUPABASE_SERVICE_ROLE_KEY
EXPO_PUBLIC_SUPABASE_URL
EXPO_PUBLIC_SUPABASE_ANON_KEY
```

`NEXT_PUBLIC_SUPABASE_URL` is absent — that is the Next.js convention used by o-sites, not this Express service. So the URL was `undefined`, `createClient` threw `supabaseUrl is required`, and because the factory sat **above** the handler's `try`, it surfaced as an unhandled 500 on every request.

**Type gate — measured both ways, because a filtered count lies here.** An earlier run showed 17 errors in a file I never touched; that run had raced a concurrent `npm install`. Compared properly:

```
with this change:   exit=2  total errors=1
clean origin/main:  exit=2  total errors=1
   src/express/routes/payments.ts(42,7): TS2322  '2025-10-29.clover' vs '2025-09-30.clover'
```

Identical, and the single error is the known pre-existing Stripe version literal already filed as #53. This change adds none.

```
$ npx jest tests/contract/limohawk-schema-qualification.test.ts
Tests:       6 passed, 6 total
```

- [x] Local tests pass — 6/6, including the new case
- [x] Cross-system claims in PR body have cite-able evidence — live curl output and the exact deployed env-var list above
- [ ] Live behaviour verified — **immediately after merge**: the endpoint should return 400 without a signature and 403 with a bad one, instead of 500.

## Test plan

- [x] New case pins the exact production condition — only `SUPABASE_URL` set, `NEXT_PUBLIC_SUPABASE_URL` deleted — and asserts the handler does real work rather than throwing at construction
- [x] **Mutation-tested**: restoring the `NEXT_PUBLIC`-only read turns that case red, and only that case
- [x] Existing 5 schema-qualification cases unaffected
- [ ] Post-deploy: confirm 400 / 403 live

## Follow-up, not fixed here

**28 call sites across this repo read `NEXT_PUBLIC_SUPABASE_URL`**, which is not set in production — Stripe page webhooks, marketplace analytics, accounts, and reviews among them. Each would throw the same way if its path is reached. This PR deliberately fixes only the loyalty webhook, which I could verify end-to-end; the wider audit needs its own ticket rather than a blind sweep, since some of those paths may be dead and a mass edit would be unverified.

Refs timebinder/o-sites#39
