### PR TITLE
fix(webhooks): build the Stripe client lazily — a module-scope one kills all four routes

### DIFF
--- a/src/handlers/webhooks/stripeLimohawk.ts
+++ b/src/handlers/webhooks/stripeLimohawk.ts
@@ -27,9 +27,33 @@ import {
 // Stripe Client
 // ============================================================================
 
-const stripe = new Stripe(process.env.LIMOHAWK_STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-09-30.clover',
-});
+/**
+ * Built lazily, NOT at module scope.
+ *
+ * `new Stripe(undefined)` throws "Neither apiKey nor config.authenticator
+ * provided". At module scope that throw happens at IMPORT time, which kills the
+ * entire serverless function before any handler runs — and `api/webhooks.ts`
+ * imports this module alongside the Twilio, Deepgram and LimoHawk loyalty
+ * handlers, so one unset key took all four routes down with it. Observed in
+ * production: every POST to /api/webhooks/limohawk returned
+ * FUNCTION_INVOCATION_FAILED, with this constructor in the stack.
+ *
+ * `LIMOHAWK_STRIPE_SECRET_KEY` is not set in this project — LimoHawk takes
+ * payment through Revolut, so this Stripe path may be vestigial entirely.
+ * Either way a route that is not configured should fail on its own when called,
+ * never at import.
+ */
+let stripeClient: Stripe | null = null;
+function getStripe(): Stripe {
+  if (!stripeClient) {
+    const key = process.env.LIMOHAWK_STRIPE_SECRET_KEY;
+    if (!key) {
+      throw new Error('LIMOHAWK_STRIPE_SECRET_KEY is not configured');
+    }
+    stripeClient = new Stripe(key, { apiVersion: '2025-09-30.clover' });
+  }
+  return stripeClient;
+}
 
 // ============================================================================
 // Configuration
@@ -96,7 +120,7 @@ export async function handleStripeLimohawkWebhook(
 
     let event: Stripe.Event;
     try {
-      event = stripe.webhooks.constructEvent(rawBodyString, signature, WEBHOOK_SECRET);
+      event = getStripe().webhooks.constructEvent(rawBodyString, signature, WEBHOOK_SECRET);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('[StripeLimohawk] Signature verification failed:', errorMessage);

--- a/tests/contract/webhooks-module-load.test.ts
+++ b/tests/contract/webhooks-module-load.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The webhooks function must LOAD without optional third-party credentials.
+ *
+ * `api/webhooks.ts` imports the Twilio, Deepgram, LimoHawk-loyalty and
+ * Stripe-LimoHawk handlers into ONE serverless function. Any module-scope
+ * client construction therefore takes all four routes down together if its key
+ * is unset — and it fails at IMPORT, so every route returns
+ * FUNCTION_INVOCATION_FAILED before a single line of handler code runs.
+ *
+ * That is exactly what happened in production: `new Stripe(undefined)` threw
+ * "Neither apiKey nor config.authenticator provided" at
+ * stripeLimohawk.ts module scope, and POST /api/webhooks/limohawk returned 500
+ * to every caller — indistinguishable from a fault in the loyalty handler,
+ * which was in fact fine.
+ *
+ * These tests fail if anyone reintroduces a module-scope client. A route that
+ * is not configured must fail when CALLED, never when imported.
+ */
+
+const STRIPE_KEYS = [
+  'LIMOHAWK_STRIPE_SECRET_KEY',
+  'LIMOHAWK_STRIPE_WEBHOOK_SECRET',
+  'STRIPE_SECRET_KEY',
+];
+
+describe('webhook handlers load without optional credentials', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of STRIPE_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of STRIPE_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('the Stripe-LimoHawk handler imports with no Stripe key set', () => {
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('../../src/handlers/webhooks/stripeLimohawk');
+    }).not.toThrow();
+  });
+
+  it('exports its handler as a function after that import', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require('../../src/handlers/webhooks/stripeLimohawk');
+    expect(typeof mod.handleStripeLimohawkWebhook).toBe('function');
+  });
+
+  it('the LimoHawk loyalty handler imports independently of Stripe config', () => {
+    // The loyalty route shares a function with the Stripe one; its availability
+    // must not depend on a payment provider LimoHawk does not even use.
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('../../src/handlers/webhooks/limohawk');
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **All four routes in the webhooks function have been dead in production.** `api/webhooks.ts` imports the Twilio, Deepgram, LimoHawk-loyalty and Stripe-LimoHawk handlers into one serverless function, and `stripeLimohawk.ts` constructed its Stripe client at **module scope** with a key this project does not have.
- `new Stripe(undefined)` throws at **import**, so the function died before any handler ran.
- Fix: lazy getter, constructed on first call with a named error when unset.

## Verification

**The actual production error**, from the runtime logs of the current deployment:

```
POST /api/webhooks/limohawk
Error: Neither apiKey nor config.authenticator provided
    at Stripe._setAuthenticator (/var/task/node_modules/stripe/cjs/stripe.core.js:158:23)
    at new Stripe (/var/task/node_modules/stripe/cjs/stripe.core.js:96:14)
    at Object.<anonymous> (/var/task/src/handlers/webhooks/stripeLimohawk.js:27:16)
Node.js process exited with exit status: 1.
```

The stack ends in `stripeLimohawk.js` at module scope — the loyalty handler is never reached. Externally this surfaced as `FUNCTION_INVOCATION_FAILED`, which is why the endpoint returned 500 to a missing signature (owes 400) and to a bad signature (owes 403).

**The key genuinely isn't there.** Exact match against the deployed environment: there are **no Stripe variables of any kind** in o-platform production.

This also explains why #56 alone didn't fix it. That change was real — the loyalty handler *did* read a non-existent `NEXT_PUBLIC_SUPABASE_URL` — but it was the second of two faults on the same request path, and the first one kills the function at import.

**Blast radius is wider than loyalty.** Twilio and Deepgram share this function and were down for the same reason. Worth noting the shape: LimoHawk takes payment through **Revolut**, so this Stripe path may be vestigial — a route nobody uses should not be able to take down three that are.

```
$ npx tsc --project api/tsconfig.json --noEmit
total errors=1     # the pre-existing payments.ts Stripe version literal (#53); none in changed files

$ npx jest tests/contract/webhooks-module-load.test.ts
Tests:       3 passed, 3 total
```

The wider `tests/contract/` suite shows 62 failures — **identical with and without this change** (measured both ways), all "No event received within timeout" from integration tests that need a live server. Pre-existing, unrelated.

- [x] Local tests pass — 3/3 new; type gate unchanged from main
- [x] Cross-system claims in PR body have cite-able evidence — production stack trace, exact env-var list, and before/after failure counts above
- [ ] Live behaviour verified — **immediately after merge**: the endpoint should return 400 without a signature and 403 with a bad one.

## Test plan

`tests/contract/webhooks-module-load.test.ts` imports the modules with every Stripe variable deleted.

- [x] **Mutation-tested**: reinstating a module-scope client turns 2 of 3 red
- [x] The Stripe-LimoHawk handler imports with no Stripe key set
- [x] It still exports its handler function after that import
- [x] The loyalty handler imports independently of Stripe config — its availability must not depend on a payment provider LimoHawk does not use
- [ ] Post-deploy: confirm 400 / 403 live rather than 500

Refs timebinder/o-sites#39
