### PR TITLE
fix(webhooks): dispatch on the rewritten sub-path — no webhook route was reachable

### DIFF
--- a/api/webhooks.ts
+++ b/api/webhooks.ts
@@ -17,8 +17,31 @@ import { handleDeepgramWebhook } from '../src/handlers/webhooks/deepgram';
 import { handleLimohawkWebhook } from '../src/handlers/webhooks/limohawk';
 import { handleStripeLimohawkWebhook } from '../src/handlers/webhooks/stripeLimohawk';
 
+/**
+ * Resolve which webhook was requested.
+ *
+ * `vercel.json` rewrites `/api/webhooks/:path*` to this function. The rewrite
+ * REPLACES the URL, so `req.url` here is `/api/webhooks` with the sub-path
+ * stripped — matching on `req.url` alone never matched anything, and every
+ * route in this function returned its own 404. The rewrite now forwards the
+ * segment as `?path=`, and we read that first.
+ *
+ * Falls back to parsing `req.url` so the function still works when invoked
+ * directly (local dev, or if the rewrite is ever removed).
+ */
+function resolveWebhookName(req: VercelRequest): string {
+  const q = (req.query || {}) as Record<string, string | string[] | undefined>;
+  const fromQuery = Array.isArray(q.path) ? q.path.join('/') : q.path;
+  if (fromQuery) return String(fromQuery).replace(/^\/+/, '');
+
+  const path = (req.url || '').split('?')[0];
+  const m = path.match(/\/webhooks\/(.+)$/);
+  return m ? m[1] : '';
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  const { url, method } = req;
+  const { method } = req;
+  const name = resolveWebhookName(req);
 
   // Only allow POST for webhooks
   if (method !== 'POST') {
@@ -27,23 +50,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 
   // Route to appropriate handler based on URL
-  if (url?.match(/\/webhooks\/twilio$/)) {
+  if (name === 'twilio') {
     // Cast to Express-like request/response for handler compatibility
     await handleTwilioWebhook(req as any, res as any);
     return;
   }
 
-  if (url?.match(/\/webhooks\/deepgram$/)) {
+  if (name === 'deepgram') {
     await handleDeepgramWebhook(req as any, res as any);
     return;
   }
 
-  if (url?.match(/\/webhooks\/limohawk$/)) {
+  if (name === 'limohawk') {
     await handleLimohawkWebhook(req as any, res as any);
     return;
   }
 
-  if (url?.match(/\/webhooks\/stripe-limohawk$/)) {
+  if (name === 'stripe-limohawk') {
     await handleStripeLimohawkWebhook(req, res);
     return;
   }

--- a/tests/contract/webhooks-routing.test.ts
+++ b/tests/contract/webhooks-routing.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Webhook sub-path dispatch.
+ *
+ * `vercel.json` rewrites `/api/webhooks/:path*` into this single function. The
+ * rewrite REPLACES the URL, so `req.url` inside the function is `/api/webhooks`
+ * with the segment stripped. The dispatch used to match on `req.url` against
+ * `/\/webhooks\/limohawk$/` and friends — which could never match — so EVERY
+ * route in this function returned its own
+ * `{"error":"Webhook endpoint not found"}` 404. Observed in production against
+ * limohawk, twilio and stripe-limohawk alike.
+ *
+ * These tests drive the handler the way the platform does.
+ */
+import handler from '../../api/webhooks';
+
+jest.mock('../../src/handlers/webhooks/twilio', () => ({
+  handleTwilioWebhook: jest.fn(async (_q: unknown, r: any) => r.status(200).json({ h: 'twilio' })),
+}));
+jest.mock('../../src/handlers/webhooks/deepgram', () => ({
+  handleDeepgramWebhook: jest.fn(async (_q: unknown, r: any) => r.status(200).json({ h: 'deepgram' })),
+}));
+jest.mock('../../src/handlers/webhooks/limohawk', () => ({
+  handleLimohawkWebhook: jest.fn(async (_q: unknown, r: any) => r.status(200).json({ h: 'limohawk' })),
+}));
+jest.mock('../../src/handlers/webhooks/stripeLimohawk', () => ({
+  handleStripeLimohawkWebhook: jest.fn(async (_q: unknown, r: any) => r.status(200).json({ h: 'stripe' })),
+}));
+
+function mockRes() {
+  const state: { code?: number; body?: any } = {};
+  const res: any = {
+    status(c: number) { state.code = c; return res; },
+    json(b: unknown) { state.body = b; return res; },
+    state,
+  };
+  return res;
+}
+
+const call = async (req: Record<string, unknown>) => {
+  const res = mockRes();
+  await handler({ method: 'POST', query: {}, ...req } as never, res as never);
+  return res.state;
+};
+
+describe('webhook sub-path dispatch', () => {
+  it('routes on the rewritten shape — url stripped, segment in ?path', async () => {
+    // This is what the platform actually delivers after the vercel.json rewrite.
+    const s = await call({ url: '/api/webhooks', query: { path: 'limohawk' } });
+    expect(s.body).toEqual({ h: 'limohawk' });
+    expect(s.code).toBe(200);
+  });
+
+  it('routes each of the four webhooks by name', async () => {
+    for (const [p, h] of [['twilio', 'twilio'], ['deepgram', 'deepgram'], ['limohawk', 'limohawk'], ['stripe-limohawk', 'stripe']]) {
+      const s = await call({ url: '/api/webhooks', query: { path: p } });
+      expect(s.body).toEqual({ h });
+    }
+  });
+
+  it('accepts ?path as an array, which is how :path* can arrive', async () => {
+    const s = await call({ url: '/api/webhooks', query: { path: ['limohawk'] } });
+    expect(s.body).toEqual({ h: 'limohawk' });
+  });
+
+  it('still routes from the full url when there is no rewrite (local/direct invocation)', async () => {
+    const s = await call({ url: '/api/webhooks/limohawk', query: {} });
+    expect(s.body).toEqual({ h: 'limohawk' });
+  });
+
+  it('ignores a query string on the url when falling back', async () => {
+    const s = await call({ url: '/api/webhooks/limohawk?foo=1', query: {} });
+    expect(s.body).toEqual({ h: 'limohawk' });
+  });
+
+  it('404s an unknown webhook name', async () => {
+    const s = await call({ url: '/api/webhooks', query: { path: 'nope' } });
+    expect(s.code).toBe(404);
+  });
+
+  it('405s a non-POST', async () => {
+    const s = await call({ method: 'GET', url: '/api/webhooks', query: { path: 'limohawk' } });
+    expect(s.code).toBe(405);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -126,7 +126,7 @@
     },
     {
       "source": "/api/webhooks/:path*",
-      "destination": "/api/webhooks"
+      "destination": "/api/webhooks?path=:path*"
     },
     {
       "source": "/api/v1/apps/photos/:path*",


### PR DESCRIPTION
## Summary

- **No route in the webhooks function has ever been reachable.** `vercel.json` rewrites `/api/webhooks/:path*` to `/api/webhooks`, which **replaces** the URL — so `req.url` inside the function is `/api/webhooks` with the segment stripped, while dispatch matched `req.url` against `/\/webhooks\/limohawk$/` and friends.
- Those regexes could never match, so control always fell through to the 404 at the bottom.
- Fix: the rewrite forwards the segment (`?path=:path*`), and dispatch reads it, falling back to parsing `req.url` for direct invocation.

## Verification

Observed in production after #58 removed the import crash — the body is the function's **own** 404, not the platform's, which is what proves the function runs and the dispatch is what fails:

```
$ curl -X POST https://api.oriva.io/api/webhooks/limohawk -d '{}'
{"error":"Webhook endpoint not found","code":"NOT_FOUND"}

/api/webhooks/limohawk        -> 404
/api/webhooks/twilio          -> 404
/api/webhooks/stripe-limohawk -> 404
/api/webhooks/nonexistent     -> 404      # identical — nothing was matching
```

The rewrite responsible, from `vercel.json`:

```json
{ "source": "/api/webhooks/:path*", "destination": "/api/webhooks" }
```

**Why this stayed hidden.** The function previously crashed at import on an unconfigured module-scope Stripe client (#58), returning 500 to everything. A 500 reads as a broken handler, so nothing suggested the routing had never worked. Fixing the crash is what surfaced this — the fifth distinct fault on this one request path, each of which alone was enough to award zero loyalty points:

1. dotted schema names in the DB calls (timebinder/o-sites#32)
2. wrong Supabase env var in this handler (#56)
3. module-scope Stripe client killing the function at import (#58)
4. **this** — sub-path never reaching dispatch
5. `LIMOHAWK_WEBHOOK_SECRET` unset, still to do

```
$ npx jest tests/contract/webhooks-routing.test.ts
Tests:       7 passed, 7 total

$ npx tsc --project api/tsconfig.json --noEmit
total errors=1     # pre-existing payments.ts Stripe literal (#53); none in changed files
```

- [x] Local tests pass — 7/7 new
- [x] Cross-system claims in PR body have cite-able evidence — live response bodies and the rewrite quoted above
- [ ] Live behaviour verified — **immediately after merge**: expect 400 without a signature and 403 with a bad one.

## Test plan

Tests drive the handler exactly as the platform does — url stripped, segment in `?path`.

- [x] **Mutation-tested**: reverting to url-only resolution turns 4 of 7 red
- [x] Routes on the rewritten shape (the real production case)
- [x] Routes all four webhooks by name — twilio, deepgram, limohawk, stripe-limohawk
- [x] Accepts `?path` as an array, which is how `:path*` can arrive
- [x] Still routes from the full url with no rewrite, so local/direct invocation keeps working
- [x] Ignores a query string when falling back
- [x] 404s an unknown name; 405s a non-POST
- [ ] Post-deploy: 400 / 403 live on `/api/webhooks/limohawk`

Refs timebinder/o-sites#39
