### PR TITLE
Ignore secrets by shape, not by enumerated filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,18 @@ api/**/*.js
 !api/test-wrapper.js
 api/**/*.js.map
 api/node_modules/
+
+# --- Secrets: ignore by SHAPE, not by filename (ultra-network#3020) ---
+# The previous rules enumerated filenames, so every new variant walked straight
+# past them: .env.production, .env.fresh, .env.vercel and ten .bak forms were all
+# committed while .env / .env.local / .env*.local were correctly ignored.
+# Ignore everything .env-shaped, then allow back only what is meant to ship.
+.env*
+!.env*example
+!.env*sample
+!.env.template
+
+# Agent / editor tooling carries credentials too — an OpenAI key reached o-core
+# history via .cursor/mcp.json, which no .env rule would ever have caught.
+.cursor/
+.aider*


### PR DESCRIPTION
## Summary

- The previous `.gitignore` rules enumerated **filenames**, so every new variant walked straight past them. o-originals correctly ignored `.env`, `.env.local` and `.env*.local` while committing `.env.production`, `.env.fresh`, `.env.vercel` and ten `.bak` forms — 54 high-confidence secret lines across ten files, six of them Supabase `service_role` keys, still tracked on `main` today.
- Now ignores everything `.env`-shaped, then allows back only what is meant to ship (`*example`, `*sample`, `.template`).
- Also ignores `.cursor/` and `.aider*`: agent and editor tooling carries credentials too — an OpenAI key reached o-core's history via `.cursor/mcp.json`, which no `.env` rule would ever have caught.

Found by the first estate-wide secrets scan, https://github.com/timebinder/ultra-network/issues/3020. Rotation and removal of the already-committed files is tracked separately on https://github.com/timebinder/ultra-network/issues/3035.

## Verification

Verified in **both** directions with `git check-ignore --no-index` against a fresh worktree off `origin/main`:

- **New secret files are blocked**: `.env.production`, `.env.fresh`, `.env.vercel.prod`, `.env.newthing.bak`, `.env.local.backup.production-urls`, `.cursor/mcp.json` — all ✓
- **Files meant to ship stay visible**: every `*example` / `*template` / `*sample` path currently tracked on `origin/main` in this repo — all ✓ (enumerated from `git ls-tree -r origin/main`, so the list is derived from the repo rather than guessed)

🔴 **The `--no-index` flag is load-bearing and worth knowing about.** `git check-ignore` does **not** report paths that are tracked, so without it the probe measures tracked-state instead of the rules — and returns a *false pass* on precisely the repo with the most committed `.env` files. The first run of this check reported `.env.production` as "not blocked" in o-originals and "blocked" in o-core with byte-identical rules; that asymmetry is what exposed the bad probe.

- [x] Local tests pass — no code changed; this is a `.gitignore`-only diff
- [x] Cross-system claims in PR body have cite-able evidence — the counts come from `gitleaks` 8.30.1 run with `--log-opts=--all`, triaged by decoding each JWT's `role` claim; inventory on https://github.com/timebinder/ultra-network/issues/3035
- [x] Live URL / DB row / user-visible behaviour verified (or explicitly deferred with reason) — N/A, `.gitignore` has no runtime surface

## Test plan

- [x] `git check-ignore --no-index` blocks each known-bad `.env` shape
- [x] `git check-ignore --no-index` leaves every tracked `*example`/`*template`/`*sample` path visible
- [x] Confirmed this does **not** untrack already-committed files — `.gitignore` never does, and that removal must follow rotation rather than precede it
- [x] Diff is one file, `.gitignore`, appended block only — no existing rules altered
