### PR TITLE
Publish the bridge operations in the SDK, CLI and MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16873,7 +16873,7 @@
     },
     "packages/cli": {
       "name": "@oriva/cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "oriva": "bin/oriva.js"
@@ -16889,7 +16889,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@oriva/sdk": "0.1.x || 0.2.x || 0.3.x"
+        "@oriva/sdk": "0.1.x || 0.2.x || 0.3.x || 0.4.x"
       },
       "peerDependenciesMeta": {
         "@oriva/sdk": {
@@ -18140,11 +18140,11 @@
     },
     "packages/mcp-server": {
       "name": "@oriva/mcp-server",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",
-        "@oriva/cli": "^0.2.0"
+        "@oriva/cli": "^0.2.0 || ^0.3.0"
       },
       "bin": {
         "oriva-mcp": "dist/index.js"
@@ -20664,7 +20664,7 @@
     },
     "packages/sdk": {
       "name": "@oriva/sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@hey-api/openapi-ts": "0.97.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Spec-driven CLI for the Oriva public API. Every endpoint is a subcommand \u2014 no Node code required to call the API.",
   "license": "MIT",
   "type": "module",
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build && npm test"
   },
   "peerDependencies": {
-    "@oriva/sdk": "0.1.x || 0.2.x || 0.3.x"
+    "@oriva/sdk": "0.1.x || 0.2.x || 0.3.x || 0.4.x"
   },
   "peerDependenciesMeta": {
     "@oriva/sdk": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/mcp-server",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Model Context Protocol server for the Oriva public API. Exposes all 46 public endpoints as MCP tools for use in Claude Code, Cursor, Continue, and Claude Desktop.",
   "license": "MIT",
   "type": "module",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.0",
-    "@oriva/cli": "^0.2.0"
+    "@oriva/cli": "^0.2.0 || ^0.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oriva/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Typed TypeScript SDK for the Oriva public API. Generated from the OpenAPI v3 spec.",
   "license": "MIT",
   "type": "module",

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -62,7 +62,15 @@ const problems = [];
 // ---- Invariant 1: internal ranges must be satisfiable locally -------------
 for (const p of pkgPaths) {
   const d = read(p);
-  const deps = { ...(d.dependencies ?? {}), ...(d.devDependencies ?? {}) };
+  // peerDependencies matter as much as the rest: @oriva/cli declares @oriva/sdk
+  // as a peer, so an sdk bump can strand that range without touching any
+  // `dependencies` block. Checking only deps+devDeps would miss it entirely.
+  const deps = {
+    ...(d.dependencies ?? {}),
+    ...(d.devDependencies ?? {}),
+    ...(d.peerDependencies ?? {}),
+    ...(d.optionalDependencies ?? {}),
+  };
   for (const [dep, range] of Object.entries(deps)) {
     const target = workspaces.get(dep);
     if (!target) continue; // external dependency, not our concern here


### PR DESCRIPTION
## Summary

Publishes the bridge operations to the toolkit. The endpoints went live on api.oriva.io with #63, but the packages never followed — no version was bumped, so the publish jobs ran, reported success, and had nothing to push. Installing `@oriva/cli` today still yields a spec with 43 paths and zero bridge.

| Package | From | To |
|---|---|---|
| `@oriva/sdk` | 0.3.0 | **0.4.0** |
| `@oriva/cli` | 0.2.2 | **0.3.0** |
| `@oriva/mcp-server` | 0.4.1 | **0.5.0** |

Minor bumps — these add operations to existing packages rather than changing any.

### Ranges widened, not repointed

Publishing three interdependent packages from one merge means three pipelines run in parallel. If the new `@oriva/cli` *required* the new `@oriva/sdk`, a consumer installing during that window could resolve a cli whose peer is not yet on the registry. Widening avoids the race entirely:

```
@oriva/cli   peerDependencies  @oriva/sdk:  0.1.x || 0.2.x || 0.3.x || 0.4.x
@oriva/mcp-server dependencies @oriva/cli:  ^0.2.0 || ^0.3.0
```

Both accept the old and new versions, so ordering cannot matter.

### The guard had a hole, and this change found it

`scripts/check-workspace-versions.mjs` read only `dependencies` and `devDependencies`. But `@oriva/cli` declares `@oriva/sdk` as a **peerDependency** — so bumping the SDK would have stranded that range while the guard reported green. Extended to cover `peerDependencies` and `optionalDependencies`.

That is not hypothetical: bumping the SDK first, before touching anything else, is exactly what surfaced it. The extended guard failed with *"@oriva/cli requires @oriva/sdk "0.1.x || 0.2.x || 0.3.x", but the workspace @oriva/sdk is 0.4.0"* — a stale peer range identical in shape to the one that broke `npm ci` in the first place (#64).

## Test plan

- [x] `npm run check:workspace-versions` — passes; and demonstrably fails on a stale peer range, which is what it was extended for
- [x] `npm ci` — exit 0
- [x] `check-openapi-drift` — passes
- [x] SDK drift guard — passes and is idempotent on the pinned codegen from #65
- [x] All four workspaces resolve as **symlinks** into `packages/`, not registry copies

Artefacts that will actually ship, inspected rather than assumed:

- `packages/cli/openapi-snapshot.json` — 48 paths, **5 bridge**
- `packages/sdk/src/generated/types.gen.ts` — **41** bridge type references
- `packages/mcp-server/src/spec.json` is gitignored and rebuilt at publish time from the canonical snapshot; verified separately that running its `copy-spec.mjs` resolves all 5 bridge paths

## Verification

The lockfile step is worth calling out because it is the failure this repo already had. After bumping, the guard refused with three problems — *"the lockfile records @oriva/cli as 0.2.2, but its package.json says 0.3.0"* and the same for the other two. That is precisely the drift that broke `npm ci` for eleven days. `npm install --package-lock-only` cleared it, and the guard now passes.

**Not verified until after merge:** that the publish jobs actually push these versions. Each package pipeline gates its publish on `github.ref == 'refs/heads/main' && github.event_name == 'push'`, so it happens on merge. Per https://github.com/0riva/oriva-platform/issues/67 the follow-up is to unpack each published tarball and confirm the bridge paths are present, rather than trusting a green pipeline — which is exactly what reported success last time while publishing nothing.

Closes https://github.com/0riva/oriva-platform/issues/67 once the published artefacts are confirmed.
